### PR TITLE
Add `static` version of `op_impls_trait` etc

### DIFF
--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -368,12 +368,19 @@ pub fn attr_impls<T: ?Sized + AttrInterfaceMarker + 'static>(attr: &dyn Attribut
     attr_cast::<T>(attr).is_some()
 }
 
-/// Does this [Attribute] type `A` implement interface `T`?
-/// This function does the lookup from the type instead of a dynamic object, which can be useful for
-/// parsing.
-/// See also: [`attr_impls`]
-pub fn attr_impls_static<A: Attribute, T: ?Sized + AttrInterfaceMarker + 'static>() -> bool {
-    impls_trait_static::<A, T>()
+/// Does [Attribute] `A` implement interface `I`?
+/// See also: [`attr_impls`].
+///
+/// Example:
+/// ```
+/// use pliron::attribute::{Attribute, attr_impls_static};
+/// use pliron::builtin::attr_interfaces::{FloatAttr, TypedAttrInterface};
+/// use pliron::builtin::attributes::IntegerAttr;
+/// assert!(attr_impls_static::<IntegerAttr, dyn TypedAttrInterface>());
+/// assert!(!attr_impls_static::<IntegerAttr, dyn FloatAttr>());
+/// ```
+pub fn attr_impls_static<A: Attribute, I: ?Sized + AttrInterfaceMarker + 'static>() -> bool {
+    impls_trait_static::<A, I>()
 }
 
 #[derive(Clone, Hash, PartialEq, Eq)]

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -65,6 +65,7 @@ use crate::{
     printable::{self, Printable},
     result::Result,
     std_deps::{hash::FxHashMap, sync::LazyLock},
+    utils::trait_cast::impls_trait_static,
 };
 
 /// Convenience type to easily print and parse key-value pairs in an [AttributeDict].
@@ -365,6 +366,14 @@ pub fn attr_cast<T: ?Sized + AttrInterfaceMarker + 'static>(attr: &dyn Attribute
 /// ```
 pub fn attr_impls<T: ?Sized + AttrInterfaceMarker + 'static>(attr: &dyn Attribute) -> bool {
     attr_cast::<T>(attr).is_some()
+}
+
+/// Does this [Attribute] type `A` implement interface `T`?
+/// This function does the lookup from the type instead of a dynamic object, which can be useful for
+/// parsing.
+/// See also: [`attr_impls`]
+pub fn attr_impls_static<A: Attribute, T: ?Sized + AttrInterfaceMarker + 'static>() -> bool {
+    impls_trait_static::<A, T>()
 }
 
 #[derive(Clone, Hash, PartialEq, Eq)]

--- a/src/op.rs
+++ b/src/op.rs
@@ -72,6 +72,7 @@ use crate::{
     result::Result,
     std_deps::{hash::FxHashMap, sync::LazyLock},
     r#type::{TypeSig, Typed},
+    utils::trait_cast::impls_trait_static,
 };
 
 #[derive(Clone, Hash, PartialEq, Eq)]
@@ -309,6 +310,14 @@ pub fn op_cast<T: ?Sized + OpInterfaceMarker + 'static>(op: &dyn Op) -> Option<&
 /// ```
 pub fn op_impls<T: ?Sized + OpInterfaceMarker + 'static>(op: &dyn Op) -> bool {
     op_cast::<T>(op).is_some()
+}
+
+/// Does this [Op] type `O` implement interface `T`?
+/// This function does the lookup from the type instead of a dynamic object, which can be useful for
+/// parsing.
+/// See also: [`op_impls`]
+pub fn op_impls_static<O: Op, T: ?Sized + OpInterfaceMarker + 'static>() -> bool {
+    impls_trait_static::<O, T>()
 }
 
 /// Every op interface must have a function named `verify` with this type.

--- a/src/op.rs
+++ b/src/op.rs
@@ -312,12 +312,19 @@ pub fn op_impls<T: ?Sized + OpInterfaceMarker + 'static>(op: &dyn Op) -> bool {
     op_cast::<T>(op).is_some()
 }
 
-/// Does this [Op] type `O` implement interface `T`?
-/// This function does the lookup from the type instead of a dynamic object, which can be useful for
-/// parsing.
+/// Does [Op] `O` implement interface `I`?
 /// See also: [`op_impls`]
-pub fn op_impls_static<O: Op, T: ?Sized + OpInterfaceMarker + 'static>() -> bool {
-    impls_trait_static::<O, T>()
+///
+/// Example:
+/// ```
+/// use pliron::builtin::op_interfaces::{SymbolTableInterface, IsTerminatorInterface};
+/// use pliron::builtin::ops::ModuleOp;
+/// use pliron::op::{Op, op_impls_static};
+/// assert!(op_impls_static::<ModuleOp, dyn SymbolTableInterface>());
+/// assert!(!op_impls_static::<ModuleOp, dyn IsTerminatorInterface>());
+/// ```
+pub fn op_impls_static<O: Op, I: ?Sized + OpInterfaceMarker + 'static>() -> bool {
+    impls_trait_static::<O, I>()
 }
 
 /// Every op interface must have a function named `verify` with this type.

--- a/src/type.rs
+++ b/src/type.rs
@@ -584,10 +584,17 @@ pub fn type_impls<T: ?Sized + TypeInterfaceMarker + 'static>(ty: &dyn Type) -> b
     type_cast::<T>(ty).is_some()
 }
 
-/// Does this [Type] type `T` implement interface `I`?
-/// This function does the lookup from the type instead of a dynamic object, which can be useful for
-/// parsing.
+/// Does [Type] `T` implement interface `I`?
 /// See also: [`type_impls`]
+///
+/// Example:
+/// ```
+/// use pliron::builtin::type_interfaces::{FunctionTypeInterface, FloatTypeInterface};
+/// use pliron::builtin::types::FunctionType;
+/// use pliron::r#type::{Type, type_impls_static};
+/// assert!(type_impls_static::<FunctionType, dyn FunctionTypeInterface>());
+/// assert!(!type_impls_static::<FunctionType, dyn FloatTypeInterface>());
+/// ```
 pub fn type_impls_static<T: Type, I: ?Sized + TypeInterfaceMarker + 'static>() -> bool {
     impls_trait_static::<T, I>()
 }

--- a/src/type.rs
+++ b/src/type.rs
@@ -50,6 +50,7 @@ use crate::{
     result::Result,
     std_deps::{hash::FxHashMap, sync::LazyLock},
     storage_uniquer::TypeValueHash,
+    utils::trait_cast::impls_trait_static,
 };
 
 use alloc::{
@@ -581,6 +582,14 @@ pub fn type_cast<T: ?Sized + TypeInterfaceMarker + 'static>(ty: &dyn Type) -> Op
 /// ```
 pub fn type_impls<T: ?Sized + TypeInterfaceMarker + 'static>(ty: &dyn Type) -> bool {
     type_cast::<T>(ty).is_some()
+}
+
+/// Does this [Type] type `T` implement interface `I`?
+/// This function does the lookup from the type instead of a dynamic object, which can be useful for
+/// parsing.
+/// See also: [`type_impls`]
+pub fn type_impls_static<T: Type, I: ?Sized + TypeInterfaceMarker + 'static>() -> bool {
+    impls_trait_static::<T, I>()
 }
 
 /// Every type interface must have a function named `verify` with this type.

--- a/src/utils/trait_cast.rs
+++ b/src/utils/trait_cast.rs
@@ -52,7 +52,21 @@ pub fn any_to_trait<T: ?Sized + 'static>(r: &dyn Any) -> Option<&T> {
         })
 }
 
-/// Check if a type implements a specific interface by checking the interface registration
+/// Check if type `T` was registered to be casted to trait `I`
+/// using [type_to_trait](crate::type_to_trait).
+///
+/// Example:
+/// ```
+/// # use pliron::{type_to_trait, utils::trait_cast::impls_trait_static};
+/// # use core::any::Any;
+/// trait Trait {}
+/// struct S;
+/// impl Trait for S {}
+/// type_to_trait!(S, Trait);
+/// assert!(impls_trait_static::<S, dyn Trait>());
+/// struct S2;
+/// assert!(!impls_trait_static::<S2, dyn Trait>());
+/// ```
 pub fn impls_trait_static<T: 'static, I: ?Sized + 'static>() -> bool {
     TRAIT_CASTERS_MAP.contains_key(&(TypeId::of::<T>(), TypeId::of::<I>()))
 }

--- a/src/utils/trait_cast.rs
+++ b/src/utils/trait_cast.rs
@@ -52,6 +52,11 @@ pub fn any_to_trait<T: ?Sized + 'static>(r: &dyn Any) -> Option<&T> {
         })
 }
 
+/// Check if a type implements a specific interface by checking the interface registration
+pub fn impls_trait_static<T: 'static, I: ?Sized + 'static>() -> bool {
+    TRAIT_CASTERS_MAP.contains_key(&(TypeId::of::<T>(), TypeId::of::<I>()))
+}
+
 #[doc(hidden)]
 /// Information to cast from a Rust type to a trait object.
 pub struct TraitCasterInfo {


### PR DESCRIPTION
Adds static versions of `op_impls_trait`, `type_impls_trait` and `attr_impls_trait`. This helps with building generic parsers, my specific use case is for detecting `SymbolOpInterface` in a custom SPIR-V canonical formatter.

The dynamic version can't be used for this because the symbol is the first symbol in the parse stream, so by the time I have a dynamic op to query the interface with, the parsing is already well past that point.