### PR TITLE
Printable impls should pass state to sub-prints

### DIFF
--- a/pliron-derive/src/derive_format.rs
+++ b/pliron-derive/src/derive_format.rs
@@ -674,7 +674,7 @@ impl PrintableBuilder<OpPrinterState> for DeriveOpPrintable {
                 if op.get_num_results() > 0 {
                     let sep = ::pliron::printable::ListSeparator::CharSpace(',');
                     let results = iter_with_sep(op.results(), sep);
-                    write!(fmt, "{} = ", results.disp(ctx))?;
+                    write!(fmt, "{} = ", results.print(ctx, state))?;
                 }
                 write!(fmt, "{} ", self.get_opid())?;
             });

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -765,7 +765,7 @@ impl Printable for CondBrOp {
     fn fmt(
         &self,
         ctx: &Context,
-        _state: &pliron::printable::State,
+        state: &pliron::printable::State,
         f: &mut core::fmt::Formatter<'_>,
     ) -> core::fmt::Result {
         let op = self.get_operation().deref(ctx);
@@ -776,19 +776,19 @@ impl Printable for CondBrOp {
             f,
             "{} if {} ^{}({}) else ^{}({})",
             Self::get_opid_static(),
-            condition.disp(ctx),
+            condition.print(ctx, state),
             op.get_successor(0).deref(ctx).unique_name(ctx),
             iter_with_sep(
                 true_dest_opds.iter(),
                 pliron::printable::ListSeparator::CharSpace(',')
             )
-            .disp(ctx),
+            .print(ctx, state),
             op.get_successor(1).deref(ctx).unique_name(ctx),
             iter_with_sep(
                 false_dest_opds.iter(),
                 pliron::printable::ListSeparator::CharSpace(',')
             )
-            .disp(ctx),
+            .print(ctx, state),
         );
         res
     }
@@ -916,19 +916,19 @@ impl Printable for SwitchCase {
     fn fmt(
         &self,
         ctx: &Context,
-        _state: &pliron::printable::State,
+        state: &pliron::printable::State,
         f: &mut core::fmt::Formatter<'_>,
     ) -> core::fmt::Result {
         write!(
             f,
             "{{ {}: ^{}({}) }}",
-            self.value.disp(ctx),
+            self.value.print(ctx, state),
             self.dest.deref(ctx).unique_name(ctx),
             list_with_sep(
                 &self.dest_opds,
                 pliron::printable::ListSeparator::CharSpace(',')
             )
-            .disp(ctx)
+            .print(ctx, state)
         )
     }
 }
@@ -985,13 +985,13 @@ impl Printable for SwitchOp {
             f,
             "{} {}, ^{}({})",
             Self::get_opid_static(),
-            condition.disp(ctx),
-            default_successor.unique_name(ctx).disp(ctx),
+            condition.print(ctx, state),
+            default_successor.unique_name(ctx).print(ctx, state),
             iter_with_sep(
                 self.successor_operands(ctx, 0).iter(),
                 pliron::printable::ListSeparator::CharSpace(',')
             )
-            .disp(ctx),
+            .print(ctx, state),
         )?;
 
         if num_total_successors < 2 {
@@ -1223,7 +1223,7 @@ impl Printable for IndirectBrDest {
     fn fmt(
         &self,
         ctx: &Context,
-        _state: &pliron::printable::State,
+        state: &pliron::printable::State,
         f: &mut core::fmt::Formatter<'_>,
     ) -> core::fmt::Result {
         write!(
@@ -1234,7 +1234,7 @@ impl Printable for IndirectBrDest {
                 &self.dest_opds,
                 pliron::printable::ListSeparator::CharSpace(',')
             )
-            .disp(ctx)
+            .print(ctx, state)
         )
     }
 }
@@ -1288,7 +1288,12 @@ impl Printable for IndirectBrOp {
         let address = op.get_operand(0);
         let dests = self.destinations(ctx);
 
-        write!(f, "{} {} [", Self::get_opid_static(), address.disp(ctx))?;
+        write!(
+            f,
+            "{} {} [",
+            Self::get_opid_static(),
+            address.print(ctx, state)
+        )?;
         indented_block!(state, {
             write!(f, "{}", indented_nl(state))?;
             list_with_sep(&dests, pliron::printable::ListSeparator::CharNewline(','))
@@ -1440,12 +1445,12 @@ impl Printable for GepIndex {
     fn fmt(
         &self,
         ctx: &Context,
-        _state: &pliron::printable::State,
+        state: &pliron::printable::State,
         f: &mut core::fmt::Formatter<'_>,
     ) -> core::fmt::Result {
         match self {
             GepIndex::Constant(c) => write!(f, "{c}"),
-            GepIndex::Value(v) => write!(f, "{}", v.disp(ctx)),
+            GepIndex::Value(v) => write!(f, "{}", v.print(ctx, state)),
         }
     }
 }
@@ -2163,14 +2168,14 @@ impl Printable for CallOp {
     fn fmt(
         &self,
         ctx: &Context,
-        _state: &pliron::printable::State,
+        state: &pliron::printable::State,
         f: &mut core::fmt::Formatter<'_>,
     ) -> core::fmt::Result {
         let callee = self.callee(ctx);
         write!(
             f,
             "{} = {} ",
-            self.get_result(ctx).disp(ctx),
+            self.get_result(ctx).print(ctx, state),
             self.get_opid()
         )?;
         match callee {
@@ -2178,14 +2183,14 @@ impl Printable for CallOp {
                 write!(f, "@{callee_sym}")?;
             }
             CallOpCallable::Indirect(callee_val) => {
-                write!(f, "{}", callee_val.disp(ctx))?;
+                write!(f, "{}", callee_val.print(ctx, state))?;
             }
         }
 
         if let Some(fmf) = self.get_attr_llvm_call_fastmath_flags(ctx)
             && *fmf != FastmathFlagsAttr::default()
         {
-            write!(f, " {}", fmf.disp(ctx))?;
+            write!(f, " {}", fmf.print(ctx, state))?;
         }
 
         let args = self.args(ctx);
@@ -2193,8 +2198,9 @@ impl Printable for CallOp {
         write!(
             f,
             " ({}) : {}",
-            list_with_sep(&args, pliron::printable::ListSeparator::CharSpace(',')).disp(ctx),
-            ty.disp(ctx)
+            list_with_sep(&args, pliron::printable::ListSeparator::CharSpace(','))
+                .print(ctx, state),
+            ty.print(ctx, state)
         )?;
         Ok(())
     }
@@ -2622,7 +2628,7 @@ impl Printable for GlobalOp {
             "{} @{} : {}",
             self.get_opid(),
             self.get_symbol_name(ctx),
-            <Self as pliron::r#type::Typed>::get_type(self, ctx).disp(ctx)
+            <Self as pliron::r#type::Typed>::get_type(self, ctx).print(ctx, state)
         )?;
 
         // Print attributes except for type, initializer and symbol name.
@@ -2638,12 +2644,12 @@ impl Printable for GlobalOp {
                 f,
                 "{}{}",
                 indented_nl(state),
-                attributes_to_print_separately.disp(ctx)
+                attributes_to_print_separately.print(ctx, state)
             )?;
         });
 
         if let Some(init_value) = self.get_initializer_value(ctx) {
-            write!(f, " = {}", init_value.disp(ctx))?;
+            write!(f, " = {}", init_value.print(ctx, state))?;
         }
 
         if let Some(init_region) = self.get_initializer_region(ctx) {
@@ -4334,12 +4340,12 @@ impl Printable for CallIntrinsicOp {
     fn fmt(
         &self,
         ctx: &Context,
-        _state: &printable::State,
+        state: &printable::State,
         f: &mut core::fmt::Formatter<'_>,
     ) -> core::fmt::Result {
         // [result = ] llvm.call_intrinsic @name <FastMathFlags> (operands) : type
         if let Some(res) = self.op.deref(ctx).results().next() {
-            write!(f, "{} = ", res.disp(ctx))?;
+            write!(f, "{} = ", res.print(ctx, state))?;
         }
 
         write!(
@@ -4348,13 +4354,13 @@ impl Printable for CallIntrinsicOp {
             Self::get_opid_static(),
             self.get_attr_llvm_intrinsic_name(ctx)
                 .expect("CallIntrinsicOp missing or incorrect intrinsic name attribute")
-                .disp(ctx),
+                .print(ctx, state),
         )?;
 
         if let Some(fmf) = self.get_attr_llvm_intrinsic_fastmath_flags(ctx)
             && *fmf != FastmathFlagsAttr::default()
         {
-            write!(f, " {} ", fmf.disp(ctx))?;
+            write!(f, " {} ", fmf.print(ctx, state))?;
         }
 
         write!(
@@ -4364,10 +4370,10 @@ impl Printable for CallIntrinsicOp {
                 self.op.deref(ctx).operands(),
                 printable::ListSeparator::CharSpace(',')
             )
-            .disp(ctx),
+            .print(ctx, state),
             self.get_attr_llvm_intrinsic_type(ctx)
                 .expect("CallIntrinsicOp missing or incorrect intrinsic type attribute")
-                .disp(ctx),
+                .print(ctx, state),
         )
     }
 }
@@ -4614,7 +4620,7 @@ impl Printable for FuncOp {
                 f,
                 "{}{}",
                 indented_nl(state),
-                attributes_to_print_separately.disp(ctx)
+                attributes_to_print_separately.print(ctx, state)
             )?;
         });
 

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -83,10 +83,10 @@ impl<'a> Printable for AttributeDictKeyVal<'a> {
     fn fmt(
         &self,
         ctx: &Context,
-        _state: &printable::State,
+        state: &printable::State,
         f: &mut core::fmt::Formatter<'_>,
     ) -> core::fmt::Result {
-        write!(f, "{}: {}", self.key, self.val.disp(ctx))
+        write!(f, "{}: {}", self.key, self.val.print(ctx, state))
     }
 }
 
@@ -110,7 +110,7 @@ impl Printable for AttributeDict {
     fn fmt(
         &self,
         ctx: &Context,
-        _state: &printable::State,
+        state: &printable::State,
         f: &mut core::fmt::Formatter<'_>,
     ) -> core::fmt::Result {
         write!(
@@ -122,7 +122,7 @@ impl Printable for AttributeDict {
                     .map(|(key, val)| AttributeDictKeyVal { key, val }),
                 printable::ListSeparator::CharSpace(','),
             )
-            .disp(ctx)
+            .print(ctx, state)
         )
     }
 }

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -452,8 +452,8 @@ impl Printable for BasicBlock {
                 self.args.iter().map(|arg| {
                     format!(
                         "{}: {}",
-                        arg.as_value(self.self_ptr).disp(ctx),
-                        arg.get_type().disp(ctx)
+                        arg.as_value(self.self_ptr).print(ctx, state),
+                        arg.get_type().print(ctx, state)
                     )
                 }),
                 ListSeparator::CharSpace(',')

--- a/src/builtin/attributes.rs
+++ b/src/builtin/attributes.rs
@@ -215,7 +215,7 @@ impl Printable for IntegerAttr {
     fn fmt(
         &self,
         ctx: &Context,
-        _state: &printable::State,
+        state: &printable::State,
         f: &mut core::fmt::Formatter<'_>,
     ) -> core::fmt::Result {
         let ty = &*self.ty.deref(ctx);
@@ -224,7 +224,7 @@ impl Printable for IntegerAttr {
             "<{}: {}>",
             self.val
                 .to_string_decimal(ty.signedness() == Signedness::Signed),
-            ty.disp(ctx)
+            ty.print(ctx, state)
         )
     }
 }
@@ -528,10 +528,10 @@ impl Printable for DictAttr {
     fn fmt(
         &self,
         ctx: &Context,
-        _state: &printable::State,
+        state: &printable::State,
         f: &mut core::fmt::Formatter<'_>,
     ) -> core::fmt::Result {
-        write!(f, "{}", self.0.disp(ctx))
+        write!(f, "{}", self.0.print(ctx, state))
     }
 }
 

--- a/src/builtin/ops.rs
+++ b/src/builtin/ops.rs
@@ -346,14 +346,14 @@ impl Printable for ForwardRefOp {
     fn fmt(
         &self,
         ctx: &Context,
-        _state: &printable::State,
+        state: &printable::State,
         f: &mut core::fmt::Formatter<'_>,
     ) -> core::fmt::Result {
         write!(
             f,
             "{} = {}",
             self.get_result(ctx).unique_name(ctx),
-            self.get_opid().disp(ctx),
+            self.get_opid().print(ctx, state),
         )
     }
 }

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -56,7 +56,7 @@ impl Printable for DebugInfoAttr {
     fn fmt(
         &self,
         ctx: &Context,
-        _state: &printable::State,
+        state: &printable::State,
         f: &mut core::fmt::Formatter<'_>,
     ) -> core::fmt::Result {
         write!(
@@ -65,7 +65,7 @@ impl Printable for DebugInfoAttr {
             self.names
                 .iter()
                 .map(|name| match name {
-                    Some(name) => name.disp(ctx).to_string(),
+                    Some(name) => name.print(ctx, state).to_string(),
                     None => "?".to_string(),
                 })
                 .collect::<Vec<_>>()

--- a/src/dialect.rs
+++ b/src/dialect.rs
@@ -102,10 +102,10 @@ impl Printable for Dialect {
     fn fmt(
         &self,
         ctx: &Context,
-        _state: &printable::State,
+        state: &printable::State,
         f: &mut core::fmt::Formatter<'_>,
     ) -> core::fmt::Result {
-        write!(f, "{}", self.name.disp(ctx))
+        write!(f, "{}", self.name.print(ctx, state))
     }
 }
 

--- a/src/inserter.rs
+++ b/src/inserter.rs
@@ -26,7 +26,7 @@ impl Printable for OpInsertionPoint {
     fn fmt(
         &self,
         ctx: &Context,
-        _state: &printable::State,
+        state: &printable::State,
         f: &mut core::fmt::Formatter<'_>,
     ) -> core::fmt::Result {
         match self {
@@ -45,10 +45,10 @@ impl Printable for OpInsertionPoint {
                 )
             }
             OpInsertionPoint::AfterOperation(op) => {
-                write!(f, "After Operation {}", op.disp(ctx))
+                write!(f, "After Operation {}", op.print(ctx, state))
             }
             OpInsertionPoint::BeforeOperation(op) => {
-                write!(f, "Before Operation {}", op.disp(ctx))
+                write!(f, "Before Operation {}", op.print(ctx, state))
             }
         }
     }

--- a/src/irbuild/dialect_conversion.rs
+++ b/src/irbuild/dialect_conversion.rs
@@ -47,7 +47,7 @@ impl Printable for OperandsInfo {
     fn fmt(
         &self,
         ctx: &Context,
-        _state: &crate::printable::State,
+        state: &crate::printable::State,
         f: &mut core::fmt::Formatter<'_>,
     ) -> core::fmt::Result {
         write!(f, "[")?;
@@ -55,9 +55,9 @@ impl Printable for OperandsInfo {
             write!(
                 f,
                 "{{Operand: {}, current type: {}, previous types: [{}]}}",
-                opd.disp(ctx),
-                opd.get_type(ctx).disp(ctx),
-                list_with_sep(previous_types, ListSeparator::CharSpace(',')).disp(ctx),
+                opd.print(ctx, state),
+                opd.get_type(ctx).print(ctx, state),
+                list_with_sep(previous_types, ListSeparator::CharSpace(',')).print(ctx, state),
             )?;
             if opd_idx != self.0.len() - 1 {
                 write!(f, ", ")?;

--- a/src/irbuild/inserter.rs
+++ b/src/irbuild/inserter.rs
@@ -45,7 +45,7 @@ impl Printable for OpInsertionPoint {
     fn fmt(
         &self,
         ctx: &Context,
-        _state: &printable::State,
+        state: &printable::State,
         f: &mut core::fmt::Formatter<'_>,
     ) -> core::fmt::Result {
         match self {
@@ -65,10 +65,10 @@ impl Printable for OpInsertionPoint {
                 )
             }
             OpInsertionPoint::AfterOperation(op) => {
-                write!(f, "After Operation {}", op.disp(ctx))
+                write!(f, "After Operation {}", op.print(ctx, state))
             }
             OpInsertionPoint::BeforeOperation(op) => {
-                write!(f, "Before Operation {}", op.disp(ctx))
+                write!(f, "Before Operation {}", op.print(ctx, state))
             }
         }
     }

--- a/src/irfmt/outlined.rs
+++ b/src/irfmt/outlined.rs
@@ -127,27 +127,28 @@ pub(crate) fn preprint_outline_block(
 /// This is called after all operations have been printed.
 pub(crate) fn print_outlines(
     ctx: &Context,
-    print_state: printable::State,
+    state: printable::State,
     f: &mut core::fmt::Formatter<'_>,
 ) -> core::fmt::Result {
-    let Some(print_state) = print_state.aux_data_mut().remove(&*OUTLINED_STATE) else {
+    let Some(outline_state) = state.aux_data_mut().remove(&*OUTLINED_STATE) else {
         return Ok(());
     };
 
-    let mut print_state = *print_state
+    let mut outline_state = *outline_state
         .downcast::<OutlinePrintState>()
         .expect("failed to downcast outline print state");
 
-    if print_state.outlined_items.is_empty() {
+    if outline_state.outlined_items.is_empty() {
         return Ok(());
     }
 
     writeln!(f, "\n\noutlined_attributes:")?;
-    let mut print_once_attr_indices = print_state.outlined_items.len();
+    let mut print_once_attr_indices = outline_state.outlined_items.len();
 
     // A helper function so we don't duplicate the per-attribute printing logic.
     fn print_outlined_attrs_for(
         ctx: &Context,
+        state: &printable::State,
         f: &mut core::fmt::Formatter<'_>,
         print_once_attrs: &mut IMap<AttrObj, usize>,
         print_once_attr_indices: &mut usize,
@@ -155,7 +156,7 @@ pub(crate) fn print_outlines(
         loc: Location,
     ) -> core::fmt::Result {
         if !loc.is_unknown() {
-            write!(f, "@[{}], ", loc.disp(ctx))?;
+            write!(f, "@[{}], ", loc.print(ctx, state))?;
         }
         write!(f, "[")?;
         let mut first = true;
@@ -176,22 +177,23 @@ pub(crate) fn print_outlines(
                         *print_once_attr_indices += 1;
                     }
                 } else {
-                    write!(f, "{} = {}", attr_name, attr.disp(ctx))?;
+                    write!(f, "{} = {}", attr_name, attr.print(ctx, state))?;
                 }
             }
         }
         Ok(())
     }
 
-    for (outidx, item) in print_state.outlined_items.iter().enumerate() {
+    for (outidx, item) in outline_state.outlined_items.iter().enumerate() {
         write!(f, "!{outidx} = ")?;
         match item {
             OutlinedItem::Op(op) => {
                 let opr = op.deref(ctx);
                 print_outlined_attrs_for(
                     ctx,
+                    &state,
                     f,
-                    &mut print_state.print_once_attrs,
+                    &mut outline_state.print_once_attrs,
                     &mut print_once_attr_indices,
                     &opr.attributes,
                     opr.loc(),
@@ -201,8 +203,9 @@ pub(crate) fn print_outlines(
                 let bl = block.deref(ctx);
                 print_outlined_attrs_for(
                     ctx,
+                    &state,
                     f,
-                    &mut print_state.print_once_attrs,
+                    &mut outline_state.print_once_attrs,
                     &mut print_once_attr_indices,
                     &bl.attributes,
                     bl.loc(),
@@ -213,9 +216,9 @@ pub(crate) fn print_outlines(
     }
 
     // Now print the PrintOnceAttrs, if any.
-    if !print_state.print_once_attrs.is_empty() {
-        for (attr, outindex) in print_state.print_once_attrs {
-            writeln!(f, "!{} = {}", outindex, attr.disp(ctx))?;
+    if !outline_state.print_once_attrs.is_empty() {
+        for (attr, outindex) in outline_state.print_once_attrs {
+            writeln!(f, "!{} = {}", outindex, attr.print(ctx, &state))?;
         }
     }
 

--- a/src/location.rs
+++ b/src/location.rs
@@ -203,12 +203,12 @@ impl Printable for Location {
     fn fmt(
         &self,
         ctx: &Context,
-        _state: &printable::State,
+        state: &printable::State,
         f: &mut core::fmt::Formatter<'_>,
     ) -> core::fmt::Result {
         match self {
             Self::SrcPos { src, pos } => {
-                write!(f, "{}: {}", src.disp(ctx), pos)
+                write!(f, "{}: {}", src.print(ctx, state), pos)
             }
             Self::Fused {
                 metadata,
@@ -216,19 +216,30 @@ impl Printable for Location {
             } => {
                 write!(f, "fused")?;
                 if let Some(metadata) = metadata {
-                    write!(f, "<{}>", metadata.disp(ctx))?;
+                    write!(f, "<{}>", metadata.print(ctx, state))?;
                 }
                 write!(
                     f,
                     "[{}]",
-                    list_with_sep(locations, printable::ListSeparator::CharSpace(',')).disp(ctx),
+                    list_with_sep(locations, printable::ListSeparator::CharSpace(','))
+                        .print(ctx, state),
                 )
             }
             Self::Named { name, child_loc } => {
-                write!(f, "name: \"{}\", loc: ({})", name, child_loc.disp(ctx))
+                write!(
+                    f,
+                    "name: \"{}\", loc: ({})",
+                    name,
+                    child_loc.print(ctx, state)
+                )
             }
             Self::CallSite { callee, caller } => {
-                write!(f, "callsite({} at {})", callee.disp(ctx), caller.disp(ctx))
+                write!(
+                    f,
+                    "callsite({} at {})",
+                    callee.print(ctx, state),
+                    caller.print(ctx, state)
+                )
             }
             Self::Unknown => write!(f, "?"),
         }

--- a/src/op.rs
+++ b/src/op.rs
@@ -435,17 +435,17 @@ pub fn canonical_syntax_print(
 
     if op.get_num_results() != 0 {
         let results = iter_with_sep(op.results(), sep);
-        write!(f, "{} = ", results.disp(ctx))?;
+        write!(f, "{} = ", results.print(ctx, state))?;
     }
 
     write!(
         f,
         "{} ({}) [{}] {}: <{}>",
-        opid.disp(ctx),
-        operands.disp(ctx),
-        successors.disp(ctx),
-        op.attributes.clone_skip_outlined().disp(ctx),
-        op_type.disp(ctx),
+        opid.print(ctx, state),
+        operands.print(ctx, state),
+        successors.print(ctx, state),
+        op.attributes.clone_skip_outlined().print(ctx, state),
+        op_type.print(ctx, state),
     )?;
 
     if op.num_regions() > 0 {

--- a/src/result.rs
+++ b/src/result.rs
@@ -162,7 +162,7 @@ impl Printable for Error {
     fn fmt(
         &self,
         ctx: &Context,
-        _state: &State,
+        state: &State,
         f: &mut core::fmt::Formatter<'_>,
     ) -> core::fmt::Result {
         if self.loc.is_unknown() {
@@ -171,15 +171,15 @@ impl Printable for Error {
             writeln!(
                 f,
                 "[{}] Compilation error: {}.",
-                self.loc.disp(ctx),
+                self.loc.print(ctx, state),
                 self.kind,
             )
         }?;
 
         if let Some(self_val) = self.err.downcast_ref::<Error>() {
-            write!(f, "{}", self_val.disp(ctx))?;
+            write!(f, "{}", self_val.print(ctx, state))?;
         } else if let Some(self_val) = any_to_trait::<dyn Printable>((*self.err).as_any()) {
-            write!(f, "{}", self_val.disp(ctx))?;
+            write!(f, "{}", self_val.print(ctx, state))?;
         } else {
             write!(f, "{}", self.err)?;
             if self.backtrace.status() == BacktraceStatus::Captured {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -92,15 +92,15 @@ impl Printable for ConstantOp {
     fn fmt(
         &self,
         ctx: &Context,
-        _state: &printable::State,
+        state: &printable::State,
         f: &mut core::fmt::Formatter<'_>,
     ) -> core::fmt::Result {
         write!(
             f,
             "{} = {} {}",
-            self.get_result(ctx).disp(ctx),
-            self.get_opid().disp(ctx),
-            self.get_value(ctx).disp(ctx)
+            self.get_result(ctx).print(ctx, state),
+            self.get_opid().print(ctx, state),
+            self.get_value(ctx).print(ctx, state)
         )
     }
 }


### PR DESCRIPTION
Inside `impl Printable`, it's always a good practice to using `Printable::print` instead of `Printable::disp` to print sub-objects so that the sub-printer gets access to the printer state.