### PR TITLE
[pliron-llvm] Add a simple life-time managing JIT wrapper

### DIFF
--- a/examples/kaleidoscope/jit.rs
+++ b/examples/kaleidoscope/jit.rs
@@ -17,7 +17,7 @@ use pliron_llvm::{
             LLVMContext, LLVMModule, llvm_get_named_function, llvm_get_param_types,
             llvm_get_return_type, llvm_global_get_value_type, llvm_int_type_in_context,
         },
-        target::initialize_native,
+        lljit::SimpleJIT,
     },
     to_llvm_ir,
 };
@@ -50,8 +50,6 @@ fn lower_to_llvm_ir(src: &str, llvm_ctx: &LLVMContext) -> Result<LLVMModule> {
 /// The function must have the signature `fn(i64) -> i64`
 // ANCHOR: exec_fn
 pub fn exec_fn(src: &str, name: &str, arg: i64) -> Result<i64> {
-    initialize_native()
-        .map_err(|e| input_error_noloc!("Failed to initialize native target: {}", e))?;
     let llvm_ctx = LLVMContext::default();
     let llvm_module = lower_to_llvm_ir(src, &llvm_ctx)?;
 
@@ -75,16 +73,12 @@ pub fn exec_fn(src: &str, name: &str, arg: i64) -> Result<i64> {
     // println!("Generated LLVM IR:\n{}", llvm_module.to_string());
 
     // JIT compile and execute the main function
-    let lljit = pliron_llvm::llvm_sys::lljit::LLVMLLJIT::new_with_default_builder()
+    let lljit = SimpleJIT::new(llvm_ctx, llvm_module)
         .map_err(|e| input_error_noloc!("Failed to create JIT execution engine: {}", e))?;
-    lljit
-        .add_module(llvm_module)
-        .map_err(|e| input_error_noloc!("Failed to add module to JIT: {}", e))?;
     let main_fn = lljit
         .lookup_symbol(name)
-        .map_err(|e| input_error_noloc!("Failed to find main function in JIT: {}", e))?;
-
-    let main_fn: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(main_fn) };
+        .map_err(|e| input_error_noloc!("Failed to add module to JIT: {}", e))?;
+    let main_fn: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(main_fn.addr) };
     Ok(main_fn(arg))
 }
 // ANCHOR_END: exec_fn

--- a/examples/kaleidoscope/jit.rs
+++ b/examples/kaleidoscope/jit.rs
@@ -77,7 +77,7 @@ pub fn exec_fn(src: &str, name: &str, arg: i64) -> Result<i64> {
         .map_err(|e| input_error_noloc!("Failed to create JIT execution engine: {}", e))?;
     let main_fn = lljit
         .lookup_symbol(name)
-        .map_err(|e| input_error_noloc!("Failed to add module to JIT: {}", e))?;
+        .map_err(|e| input_error_noloc!("Failed to lookup symbol {} in JIT: {}", name, e))?;
     let main_fn: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(main_fn.addr) };
     Ok(main_fn(arg))
 }

--- a/examples/kaleidoscope/jit.rs
+++ b/examples/kaleidoscope/jit.rs
@@ -17,7 +17,7 @@ use pliron_llvm::{
             LLVMContext, LLVMModule, llvm_get_named_function, llvm_get_param_types,
             llvm_get_return_type, llvm_global_get_value_type, llvm_int_type_in_context,
         },
-        lljit::SimpleJIT,
+        lljit::{JitSymbol, SimpleJIT},
     },
     to_llvm_ir,
 };
@@ -75,10 +75,8 @@ pub fn exec_fn(src: &str, name: &str, arg: i64) -> Result<i64> {
     // JIT compile and execute the main function
     let lljit = SimpleJIT::new(llvm_ctx, llvm_module)
         .map_err(|e| input_error_noloc!("Failed to create JIT execution engine: {}", e))?;
-    let main_fn = lljit
-        .lookup_symbol(name)
+    let main_fn: JitSymbol<fn(i64) -> i64> = unsafe { lljit.lookup_symbol(name) }
         .map_err(|e| input_error_noloc!("Failed to find main function in JIT: {}", e))?;
-    let main_fn: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(main_fn.addr) };
     Ok(main_fn(arg))
 }
 // ANCHOR_END: exec_fn

--- a/examples/kaleidoscope/jit.rs
+++ b/examples/kaleidoscope/jit.rs
@@ -77,7 +77,7 @@ pub fn exec_fn(src: &str, name: &str, arg: i64) -> Result<i64> {
         .map_err(|e| input_error_noloc!("Failed to create JIT execution engine: {}", e))?;
     let main_fn = lljit
         .lookup_symbol(name)
-        .map_err(|e| input_error_noloc!("Failed to lookup symbol {} in JIT: {}", name, e))?;
+        .map_err(|e| input_error_noloc!("Failed to find main function in JIT: {}", e))?;
     let main_fn: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(main_fn.addr) };
     Ok(main_fn(arg))
 }

--- a/kaleidoscope/src/ch5-jit.md
+++ b/kaleidoscope/src/ch5-jit.md
@@ -46,13 +46,12 @@ The public API for execution is `exec_fn`:
 
 Key parts of `exec_fn`:
 
-- `initialize_native()` sets up the host target backend once per process.
 - `llvm_get_named_function` checks that the requested symbol exists in the generated module.
 - `llvm_get_param_types` and `llvm_get_return_type` are used to validate the function ABI as exactly one `i64` argument and an `i64` return value.
-- `LLVMLLJIT::new_with_default_builder()` creates an ORC JIT instance.
-- `add_module` loads the generated LLVM module into JIT.
-- `lookup_symbol(name)` resolves the function entry address.
-- `std::mem::transmute` casts the raw symbol address to `extern "C" fn(i64) -> i64`, then calls it.
+- `SimpleJIT::new(llvm_ctx, llvm_module)` creates a simple JIT instance,
+wrapping over LLVM's LLJIT.
+- `lookup_symbol(name)` resolves the function entry address, returning a `JitSymbol` whose `addr` field holds the raw address.
+- `std::mem::transmute` casts `main_fn.addr` to `extern "C" fn(i64) -> i64`, then calls it.
 
 If the function is missing, or has a different signature, `exec_fn` returns a
 structured `pliron::result::Error` instead of panicking.

--- a/kaleidoscope/src/ch5-jit.md
+++ b/kaleidoscope/src/ch5-jit.md
@@ -47,11 +47,12 @@ The public API for execution is `exec_fn`:
 Key parts of `exec_fn`:
 
 - `llvm_get_named_function` checks that the requested symbol exists in the generated module.
-- `llvm_get_param_types` and `llvm_get_return_type` are used to validate the function ABI as exactly one `i64` argument and an `i64` return value.
+- `llvm_get_param_types` and `llvm_get_return_type` are used to validate the function ABI as
+exactly one `i64` argument and an `i64` return value.
 - `SimpleJIT::new(llvm_ctx, llvm_module)` creates a simple JIT instance,
 wrapping over LLVM's LLJIT.
-- `lookup_symbol(name)` resolves the function entry address, returning a `JitSymbol` whose `addr` field holds the raw address.
-- `std::mem::transmute` casts `main_fn.addr` to `extern "C" fn(i64) -> i64`, then calls it.
+- `lookup_symbol(name)` resolves the function entry address, returning a `JitSymbol`.
+- Execute the JIT compiled function from its `JitSymbol`.
 
 If the function is missing, or has a different signature, `exec_fn` returns a
 structured `pliron::result::Error` instead of panicking.

--- a/pliron-llvm/src/function_call_utils.rs
+++ b/pliron-llvm/src/function_call_utils.rs
@@ -262,8 +262,10 @@ mod tests {
 
         // Execute the LLVM IR using the JIT and check it runs without errors
         let jit = SimpleJIT::new(llvm_ctx, llvm_ir).expect("SimpleJIT creation failed");
-        let main_fn = jit.lookup_symbol("main").expect("main not found in JIT");
-        let main_fn = unsafe { core::mem::transmute::<u64, fn() -> u64>(main_fn.addr) };
+        let main_fn = unsafe {
+            jit.lookup_symbol::<fn() -> u64>("main")
+                .expect("main not found in JIT")
+        };
         let fp_ty_size = main_fn();
         assert_eq!(
             fp_ty_size, 8,

--- a/pliron-llvm/src/function_call_utils.rs
+++ b/pliron-llvm/src/function_call_utils.rs
@@ -162,7 +162,7 @@ mod tests {
             compute_type_size_in_bytes, get_size_type, lookup_or_create_free_fn,
             lookup_or_create_malloc_fn,
         },
-        llvm_sys::{core::LLVMContext, lljit::LLVMLLJIT, target},
+        llvm_sys::{core::LLVMContext, lljit::SimpleJIT},
         ops::{CallOp, FuncOp, ReturnOp},
         to_llvm_ir::convert_module,
         types::FuncType,
@@ -261,14 +261,9 @@ mod tests {
         llvm_ir.verify().expect("Generated LLVM IR is invalid");
 
         // Execute the LLVM IR using the JIT and check it runs without errors
-        target::initialize_native().expect("Failed to initialize native target for JIT");
-        let jit = LLVMLLJIT::new_with_default_builder().expect("Failed to create LLJIT instance");
-        jit.add_module(llvm_ir)
-            .expect("Failed to add module to JIT");
-        let main_addr = jit
-            .lookup_symbol("main")
-            .expect("Failed to lookup 'main' symbol");
-        let main_fn = unsafe { core::mem::transmute::<u64, fn() -> u64>(main_addr) };
+        let jit = SimpleJIT::new(llvm_ctx, llvm_ir).expect("SimpleJIT creation failed");
+        let main_fn = jit.lookup_symbol("main").expect("main not found in JIT");
+        let main_fn = unsafe { core::mem::transmute::<u64, fn() -> u64>(main_fn.addr) };
         let fp_ty_size = main_fn();
         assert_eq!(
             fp_ty_size, 8,

--- a/pliron-llvm/src/llvm_sys/core.rs
+++ b/pliron-llvm/src/llvm_sys/core.rs
@@ -2713,8 +2713,12 @@ mod llvm_module {
         }
 
         /// Parse IR from [str] into [LLVMModule]
-        pub fn from_str(context: &LLVMContext, ir: &str) -> Result<LLVMModule, String> {
-            let memory_buffer = LLVMMemoryBuffer::from_str(ir, "llmod");
+        pub fn from_ir_in_str(
+            context: &LLVMContext,
+            ir: &str,
+            module_name: Option<&str>,
+        ) -> Result<LLVMModule, String> {
+            let memory_buffer = LLVMMemoryBuffer::from_str(ir, module_name.unwrap_or("llmod"));
             Self::from_ir_in_memory_buffer(context, memory_buffer)
         }
 

--- a/pliron-llvm/src/llvm_sys/core.rs
+++ b/pliron-llvm/src/llvm_sys/core.rs
@@ -154,7 +154,7 @@ mod llvm_context {
     }
 
     impl LLVMContext {
-        pub(super) fn inner_ref(&self) -> LLVMContextRef {
+        pub(in crate::llvm_sys) fn inner_ref(&self) -> LLVMContextRef {
             self.0
         }
     }

--- a/pliron-llvm/src/llvm_sys/core.rs
+++ b/pliron-llvm/src/llvm_sys/core.rs
@@ -2713,7 +2713,7 @@ mod llvm_module {
         }
 
         /// Parse IR from [str] into [LLVMModule]
-        pub fn from_ir(context: &LLVMContext, ir: &str) -> Result<LLVMModule, String> {
+        pub fn from_str(context: &LLVMContext, ir: &str) -> Result<LLVMModule, String> {
             let memory_buffer = LLVMMemoryBuffer::from_str(ir, "llmod");
             Self::from_ir_in_memory_buffer(context, memory_buffer)
         }

--- a/pliron-llvm/src/llvm_sys/core.rs
+++ b/pliron-llvm/src/llvm_sys/core.rs
@@ -2712,6 +2712,12 @@ mod llvm_module {
             })
         }
 
+        /// Parse IR from [str] into [LLVMModule]
+        pub fn from_ir(context: &LLVMContext, ir: &str) -> Result<LLVMModule, String> {
+            let memory_buffer = LLVMMemoryBuffer::from_str(ir, "llmod");
+            Self::from_ir_in_memory_buffer(context, memory_buffer)
+        }
+
         /// Parse IR in memory buffer to [LLVMModule]
         pub fn from_ir_in_memory_buffer(
             context: &LLVMContext,

--- a/pliron-llvm/src/llvm_sys/lljit.rs
+++ b/pliron-llvm/src/llvm_sys/lljit.rs
@@ -45,7 +45,7 @@
 //! ```
 
 use bitflags::bitflags;
-use core::{mem, ptr};
+use core::{marker::PhantomData, mem, ops::Deref, ptr};
 
 use llvm_sys::{
     core::LLVMGetModuleContext,
@@ -229,31 +229,51 @@ impl Drop for LLVMLLJIT {
 /// let context = LLVMContext::default();
 ///
 /// let ir = r#"
+///   @sum_global = global i32 0
+///
 ///   define i32 @add(i32 %a, i32 %b) {
 ///       %sum = add i32 %a, %b
+///       store i32 %sum, ptr @sum_global
 ///       ret i32 %sum
 ///   }"#;
 ///
 /// let module = LLVMModule::from_ir_in_str(&context, ir, None).unwrap();
 ///
 /// let jit = SimpleJIT::new(context, module).unwrap();
-/// let symbol = jit.lookup_symbol("add").unwrap();
-///
-/// let adder = unsafe { std::mem::transmute::<u64, fn(i32, i32) -> i32>(symbol.addr) };
+/// let adder = unsafe { jit.lookup_symbol::<fn(i32, i32) -> i32>("add").unwrap() };
 /// assert_eq!(adder(2, 3), 5);
+///
+/// // The global is updated as a side effect of calling `add`, and can be
+/// // looked up (as a pointer to its storage).
+/// let sum_global = unsafe { jit.lookup_symbol::<*const i32>("sum_global").unwrap() };
+/// assert_eq!(unsafe { **sum_global }, 5);
 /// ```
 pub struct SimpleJIT {
     jit: LLVMLLJIT,
 }
 
-/// A symbol address looked up in [SimpleJIT].
-pub struct JitSymbol<'jit> {
-    pub addr: u64,
-    _jit: &'jit SimpleJIT,
+/// A symbol looked up in [SimpleJIT], typed as the function pointer `F`.
+///
+/// Borrows the [SimpleJIT] it was looked up from, so it can't outlive the JIT
+/// (and therefore can't outlive the compiled code it points into). Dereferences
+/// to `F`, so it can be called directly.
+pub struct JitSymbol<'jit, F: Copy> {
+    f: F,
+    _jit: PhantomData<&'jit SimpleJIT>,
+}
+
+impl<'jit, F: Copy> Deref for JitSymbol<'jit, F> {
+    type Target = F;
+
+    fn deref(&self) -> &F {
+        &self.f
+    }
 }
 
 impl SimpleJIT {
     /// Create a JIT from `llmod` and the `context` that contains it.
+    ///
+    /// See type documentation for examples.
     pub fn new(context: LLVMContext, llmod: LLVMModule) -> Result<Self, String> {
         initialize_native()?;
         let jit = LLVMLLJIT::new_with_default_builder()?;
@@ -261,10 +281,23 @@ impl SimpleJIT {
         Ok(SimpleJIT { jit })
     }
 
-    /// Lookup a symbol in the JIT.
-    pub fn lookup_symbol<'jit>(&'jit self, symbol_name: &str) -> Result<JitSymbol<'jit>, String> {
+    /// Lookup a symbol in the JIT and interpret it to be of type `F`.
+    ///
+    /// See type documentation for examples.
+    ///
+    /// # Safety
+    /// The type of the symbol must be correct.
+    pub unsafe fn lookup_symbol<'jit, T: Copy>(
+        &'jit self,
+        symbol_name: &str,
+    ) -> Result<JitSymbol<'jit, T>, String> {
+        const { assert!(mem::size_of::<T>() == mem::size_of::<u64>()) };
         let addr = self.jit.lookup_symbol(symbol_name)?;
         assert!(addr != 0);
-        Ok(JitSymbol { addr, _jit: self })
+        let f = unsafe { mem::transmute_copy::<u64, T>(&addr) };
+        Ok(JitSymbol {
+            f,
+            _jit: PhantomData,
+        })
     }
 }

--- a/pliron-llvm/src/llvm_sys/lljit.rs
+++ b/pliron-llvm/src/llvm_sys/lljit.rs
@@ -47,10 +47,14 @@
 use bitflags::bitflags;
 use core::{mem, ptr};
 
-use llvm_sys::orc2::{
-    LLVMJITEvaluatedSymbol, LLVMJITSymbolFlags, LLVMJITSymbolGenericFlags, LLVMOrcAbsoluteSymbols,
-    LLVMOrcCSymbolMapPair, LLVMOrcCreateNewThreadSafeContextFromLLVMContext,
-    LLVMOrcCreateNewThreadSafeModule, LLVMOrcDisposeThreadSafeContext, lljit,
+use llvm_sys::{
+    core::LLVMGetModuleContext,
+    orc2::{
+        LLVMJITEvaluatedSymbol, LLVMJITSymbolFlags, LLVMJITSymbolGenericFlags,
+        LLVMOrcAbsoluteSymbols, LLVMOrcCSymbolMapPair,
+        LLVMOrcCreateNewThreadSafeContextFromLLVMContext, LLVMOrcCreateNewThreadSafeModule,
+        LLVMOrcDisposeThreadSafeContext, lljit,
+    },
 };
 
 use crate::llvm_sys::{
@@ -135,6 +139,7 @@ impl LLVMLLJIT {
     /// Add an [LLVMModule] (contained in [LLVMContext]) to the JIT's main JITDylib
     pub fn add_module(&self, context: LLVMContext, module: LLVMModule) -> Result<(), String> {
         unsafe {
+            assert_eq!(context.inner_ref(), LLVMGetModuleContext(module.inner_ref()));
             let tsctx = LLVMOrcCreateNewThreadSafeContextFromLLVMContext(context.inner_ref());
             // Ownership of the context has been transferred to the thread-safe context
             mem::forget(context);

--- a/pliron-llvm/src/llvm_sys/lljit.rs
+++ b/pliron-llvm/src/llvm_sys/lljit.rs
@@ -54,8 +54,10 @@ use llvm_sys::orc2::{
 };
 
 use crate::llvm_sys::{
-    core::{LLVMModule, handle_err},
-    cstr_to_string, to_c_str,
+    core::{LLVMContext, LLVMModule, handle_err},
+    cstr_to_string,
+    target::initialize_native,
+    to_c_str,
 };
 
 bitflags! {
@@ -207,5 +209,63 @@ impl Drop for LLVMLLJIT {
                 panic!("Error disposing LLJIT: {}", err);
             }
         }
+    }
+}
+
+/// A convenience wrapper around [LLVMLLJIT].
+///
+/// It takes ownership of the [LLVMModule] to be compiled and its owning [LLVMContext].
+///
+/// ### Example
+/// ```
+/// use pliron_llvm::llvm_sys::core::{LLVMContext, LLVMMemoryBuffer, LLVMModule};
+/// use pliron_llvm::llvm_sys::lljit::SimpleJIT;
+///
+/// let context = LLVMContext::default();
+///
+/// let ir = r#"
+///   define i32 @add(i32 %a, i32 %b) {
+///       %sum = add i32 %a, %b
+///       ret i32 %sum
+///   }"#;
+///
+/// let module = LLVMModule::from_ir(&context, ir).unwrap();
+///
+/// let jit = SimpleJIT::new_from_module(context, module);
+/// let symbol = jit.lookup_symbol("add");
+///
+/// let adder = unsafe { std::mem::transmute::<u64, fn(i32, i32) -> i32>(symbol.addr) };
+/// assert_eq!(adder(2, 3), 5);
+/// ```
+pub struct SimpleJIT {
+    jit: LLVMLLJIT,
+    // Held only to keep the context alive as long as `jit` is.
+    #[allow(dead_code)]
+    context: LLVMContext,
+}
+
+/// A symbol address looked up in [SimpleJIT].
+pub struct JitSymbol<'jit> {
+    pub addr: u64,
+    _jit: &'jit SimpleJIT,
+}
+
+impl SimpleJIT {
+    /// Create a JIT from `llmod` and the `context` that contains it.
+    pub fn new_from_module(context: LLVMContext, llmod: LLVMModule) -> Self {
+        initialize_native().expect("Failed to initialize native target for LLVM execution");
+        let jit = LLVMLLJIT::new_with_default_builder().expect("Failed to create LLJIT");
+        jit.add_module(llmod).expect("Failed to add module to JIT");
+        SimpleJIT { jit, context }
+    }
+
+    /// Lookup a symbol in the JIT.
+    pub fn lookup_symbol<'jit>(&'jit self, symbol_name: &str) -> JitSymbol<'jit> {
+        let addr = self
+            .jit
+            .lookup_symbol(symbol_name)
+            .expect("Failed to lookup symbol");
+        assert!(addr != 0);
+        JitSymbol { addr, _jit: self }
     }
 }

--- a/pliron-llvm/src/llvm_sys/lljit.rs
+++ b/pliron-llvm/src/llvm_sys/lljit.rs
@@ -229,7 +229,7 @@ impl Drop for LLVMLLJIT {
 ///       ret i32 %sum
 ///   }"#;
 ///
-/// let module = LLVMModule::from_ir(&context, ir).unwrap();
+/// let module = LLVMModule::from_str(&context, ir).unwrap();
 ///
 /// let jit = SimpleJIT::new_from_module(context, module);
 /// let symbol = jit.lookup_symbol("add");

--- a/pliron-llvm/src/llvm_sys/lljit.rs
+++ b/pliron-llvm/src/llvm_sys/lljit.rs
@@ -26,7 +26,7 @@
 //!    let module = LLVMModule::from_ir_in_memory_buffer(&context, ir_mb)?;
 //!
 //!    let jit = LLVMLLJIT::new_with_default_builder()?;
-//!    jit.add_module(module)?;
+//!    jit.add_module(context, module)?;
 //!    // Add the Rust function as a symbol mapping
 //!    let rust_adder_addr = my_rust_adder as *const () as u64;
 //!    jit.add_symbol_mapping
@@ -45,12 +45,12 @@
 //! ```
 
 use bitflags::bitflags;
-use std::{mem::MaybeUninit, ptr};
+use core::{mem, ptr};
 
 use llvm_sys::orc2::{
     LLVMJITEvaluatedSymbol, LLVMJITSymbolFlags, LLVMJITSymbolGenericFlags, LLVMOrcAbsoluteSymbols,
-    LLVMOrcCSymbolMapPair, LLVMOrcCreateNewThreadSafeContext, LLVMOrcCreateNewThreadSafeModule,
-    LLVMOrcDisposeThreadSafeContext, LLVMOrcDisposeThreadSafeModule, lljit,
+    LLVMOrcCSymbolMapPair, LLVMOrcCreateNewThreadSafeContextFromLLVMContext,
+    LLVMOrcCreateNewThreadSafeModule, LLVMOrcDisposeThreadSafeContext, lljit,
 };
 
 use crate::llvm_sys::{
@@ -125,36 +125,33 @@ impl LLVMLLJIT {
     /// Create a new LLJIT instance with default settings.
     pub fn new_with_default_builder() -> Result<Self, String> {
         unsafe {
-            let mut jit = MaybeUninit::uninit();
+            let mut jit = mem::MaybeUninit::uninit();
             let err = lljit::LLVMOrcCreateLLJIT(jit.as_mut_ptr(), ptr::null_mut());
             handle_err(err)?;
             Ok(LLVMLLJIT(jit.assume_init()))
         }
     }
 
-    /// Add an [LLVMModule] to the JIT's main JITDylib, in its own thread-safe context.
-    pub fn add_module(&self, module: LLVMModule) -> Result<(), String> {
+    /// Add an [LLVMModule] (contained in [LLVMContext]) to the JIT's main JITDylib
+    pub fn add_module(&self, context: LLVMContext, module: LLVMModule) -> Result<(), String> {
         unsafe {
-            let tsctx = LLVMOrcCreateNewThreadSafeContext();
+            let tsctx = LLVMOrcCreateNewThreadSafeContextFromLLVMContext(context.inner_ref());
+            // Ownership of the context has been transferred to the thread-safe context
+            mem::forget(context);
             let tsm = LLVMOrcCreateNewThreadSafeModule(module.inner_ref(), tsctx);
             let main_jd = lljit::LLVMOrcLLJITGetMainJITDylib(self.0);
             let err = lljit::LLVMOrcLLJITAddLLVMIRModule(self.0, main_jd, tsm);
-            // The underlying LLVMContext will be kept alive by our ThreadSafeModule
-            // (See OrcV2CBindingsBasicUsage.c)
             LLVMOrcDisposeThreadSafeContext(tsctx);
             // Ownership of the module has been transferred to the JIT
-            std::mem::forget(module);
-            handle_err(err).inspect_err(|_| {
-                // Dispose of the ThreadSafeModule on error
-                LLVMOrcDisposeThreadSafeModule(tsm);
-            })
+            mem::forget(module);
+            handle_err(err)
         }
     }
 
     /// Lookup a symbol in the JIT.
     pub fn lookup_symbol(&self, name: &str) -> Result<u64, String> {
         unsafe {
-            let mut addr = MaybeUninit::uninit();
+            let mut addr = mem::MaybeUninit::uninit();
             let err = lljit::LLVMOrcLLJITLookup(self.0, addr.as_mut_ptr(), to_c_str(name).as_ptr());
             handle_err(err)?;
             Ok(addr.assume_init())
@@ -231,17 +228,14 @@ impl Drop for LLVMLLJIT {
 ///
 /// let module = LLVMModule::from_ir_in_str(&context, ir, None).unwrap();
 ///
-/// let jit = SimpleJIT::new_from_module(context, module);
-/// let symbol = jit.lookup_symbol("add");
+/// let jit = SimpleJIT::new(context, module).unwrap();
+/// let symbol = jit.lookup_symbol("add").unwrap();
 ///
 /// let adder = unsafe { std::mem::transmute::<u64, fn(i32, i32) -> i32>(symbol.addr) };
 /// assert_eq!(adder(2, 3), 5);
 /// ```
 pub struct SimpleJIT {
     jit: LLVMLLJIT,
-    // Held only to keep the context alive as long as `jit` is.
-    #[allow(dead_code)]
-    context: LLVMContext,
 }
 
 /// A symbol address looked up in [SimpleJIT].
@@ -252,20 +246,17 @@ pub struct JitSymbol<'jit> {
 
 impl SimpleJIT {
     /// Create a JIT from `llmod` and the `context` that contains it.
-    pub fn new_from_module(context: LLVMContext, llmod: LLVMModule) -> Self {
-        initialize_native().expect("Failed to initialize native target for LLVM execution");
-        let jit = LLVMLLJIT::new_with_default_builder().expect("Failed to create LLJIT");
-        jit.add_module(llmod).expect("Failed to add module to JIT");
-        SimpleJIT { jit, context }
+    pub fn new(context: LLVMContext, llmod: LLVMModule) -> Result<Self, String> {
+        initialize_native()?;
+        let jit = LLVMLLJIT::new_with_default_builder()?;
+        jit.add_module(context, llmod)?;
+        Ok(SimpleJIT { jit })
     }
 
     /// Lookup a symbol in the JIT.
-    pub fn lookup_symbol<'jit>(&'jit self, symbol_name: &str) -> JitSymbol<'jit> {
-        let addr = self
-            .jit
-            .lookup_symbol(symbol_name)
-            .expect("Failed to lookup symbol");
+    pub fn lookup_symbol<'jit>(&'jit self, symbol_name: &str) -> Result<JitSymbol<'jit>, String> {
+        let addr = self.jit.lookup_symbol(symbol_name)?;
         assert!(addr != 0);
-        JitSymbol { addr, _jit: self }
+        Ok(JitSymbol { addr, _jit: self })
     }
 }

--- a/pliron-llvm/src/llvm_sys/lljit.rs
+++ b/pliron-llvm/src/llvm_sys/lljit.rs
@@ -139,7 +139,10 @@ impl LLVMLLJIT {
     /// Add an [LLVMModule] (contained in [LLVMContext]) to the JIT's main JITDylib
     pub fn add_module(&self, context: LLVMContext, module: LLVMModule) -> Result<(), String> {
         unsafe {
-            assert_eq!(context.inner_ref(), LLVMGetModuleContext(module.inner_ref()));
+            assert_eq!(
+                context.inner_ref(),
+                LLVMGetModuleContext(module.inner_ref())
+            );
             let tsctx = LLVMOrcCreateNewThreadSafeContextFromLLVMContext(context.inner_ref());
             // Ownership of the context has been transferred to the thread-safe context
             mem::forget(context);

--- a/pliron-llvm/src/llvm_sys/lljit.rs
+++ b/pliron-llvm/src/llvm_sys/lljit.rs
@@ -229,7 +229,7 @@ impl Drop for LLVMLLJIT {
 ///       ret i32 %sum
 ///   }"#;
 ///
-/// let module = LLVMModule::from_str(&context, ir).unwrap();
+/// let module = LLVMModule::from_ir_in_str(&context, ir, None).unwrap();
 ///
 /// let jit = SimpleJIT::new_from_module(context, module);
 /// let symbol = jit.lookup_symbol("add");

--- a/pliron-llvm/src/llvm_sys/lljit.rs
+++ b/pliron-llvm/src/llvm_sys/lljit.rs
@@ -123,6 +123,9 @@ impl From<JITSymbolGenericFlags> for u8 {
     }
 }
 
+/// Wrapper around LLVM's LLJIT.
+///
+/// For simple uses, considering using [SimpleJIT].
 pub struct LLVMLLJIT(lljit::LLVMOrcLLJITRef);
 
 impl LLVMLLJIT {


### PR DESCRIPTION
It also changes the type signature of `LLVMLLJIT::add_module` to also take ownership of the module's container `Context`, fixing an ownership bug.