### PR TITLE
[pliron-llvm]: Simplify `OpToLLVMConstValue` for `ConstantOp`

### DIFF
--- a/pliron-llvm/src/attributes.rs
+++ b/pliron-llvm/src/attributes.rs
@@ -15,7 +15,7 @@ use pliron::{
     combine::{self, Parser, choice, parser::char::spaces},
     common_traits::Verify,
     context::Context,
-    derive::{format, pliron_attr},
+    derive::{attr_interface_impl, format, pliron_attr},
     impl_printable_for_display, input_error,
     location::Located,
     parsable::{IntoParseResult, Parsable},
@@ -250,6 +250,7 @@ pub struct AddressSpaceAttr(pub u32);
 #[derive(PartialEq, Eq, Clone, Debug, Hash)]
 pub struct ZeroAttr(pub TypeHandle);
 
+#[attr_interface_impl]
 impl TypedAttrInterface for ZeroAttr {
     fn get_type(&self, _ctx: &Context) -> TypeHandle {
         self.0
@@ -261,6 +262,7 @@ impl TypedAttrInterface for ZeroAttr {
 #[derive(PartialEq, Eq, Clone, Debug, Hash)]
 pub struct UndefAttr(pub TypeHandle);
 
+#[attr_interface_impl]
 impl TypedAttrInterface for UndefAttr {
     fn get_type(&self, _ctx: &Context) -> TypeHandle {
         self.0
@@ -272,6 +274,7 @@ impl TypedAttrInterface for UndefAttr {
 #[derive(PartialEq, Eq, Clone, Debug, Hash)]
 pub struct PoisonAttr(pub TypeHandle);
 
+#[attr_interface_impl]
 impl TypedAttrInterface for PoisonAttr {
     fn get_type(&self, _ctx: &Context) -> TypeHandle {
         self.0

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -62,7 +62,7 @@ use crate::{
     attributes::{
         AddressSpaceAttr, AlignmentAttr, AtomicOrderingAttr, AtomicRmwKindAttr, CaseValuesAttr,
         FCmpPredicateAttr, FastmathFlagsAttr, InsertExtractValueIndicesAttr, LinkageAttr,
-        PoisonAttr, ShuffleVectorMaskAttr, UndefAttr, ZeroAttr,
+        ShuffleVectorMaskAttr,
     },
     op_interfaces::{
         AlignableOpInterface, BinArithOp, CastOpInterface, CastOpWithNNegInterface, FastMathFlags,
@@ -2349,12 +2349,7 @@ impl Verify for ConstantOp {
     fn verify(&self, ctx: &Context) -> Result<()> {
         let loc = self.loc(ctx);
         let value = self.get_value(ctx);
-        if !(value.is::<IntegerAttr>()
-            || attr_impls::<dyn FloatAttr>(&*value)
-            || value.is::<ZeroAttr>()
-            || value.is::<PoisonAttr>()
-            || value.is::<UndefAttr>())
-        {
+        if !(value.is::<IntegerAttr>() || attr_impls::<dyn FloatAttr>(&*value)) {
             verify_err!(loc, ConstantOpVerifyErr::InvalidValue)?;
         }
         Ok(())

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -62,7 +62,7 @@ use crate::{
     attributes::{
         AddressSpaceAttr, AlignmentAttr, AtomicOrderingAttr, AtomicRmwKindAttr, CaseValuesAttr,
         FCmpPredicateAttr, FastmathFlagsAttr, InsertExtractValueIndicesAttr, LinkageAttr,
-        ShuffleVectorMaskAttr,
+        PoisonAttr, ShuffleVectorMaskAttr, UndefAttr, ZeroAttr,
     },
     op_interfaces::{
         AlignableOpInterface, BinArithOp, CastOpInterface, CastOpWithNNegInterface, FastMathFlags,
@@ -2349,7 +2349,12 @@ impl Verify for ConstantOp {
     fn verify(&self, ctx: &Context) -> Result<()> {
         let loc = self.loc(ctx);
         let value = self.get_value(ctx);
-        if !(value.is::<IntegerAttr>() || attr_impls::<dyn FloatAttr>(&*value)) {
+        if !(value.is::<IntegerAttr>()
+            || attr_impls::<dyn FloatAttr>(&*value)
+            || value.is::<ZeroAttr>()
+            || value.is::<PoisonAttr>()
+            || value.is::<UndefAttr>())
+        {
             verify_err!(loc, ConstantOpVerifyErr::InvalidValue)?;
         }
         Ok(())

--- a/pliron-llvm/src/to_llvm_ir.rs
+++ b/pliron-llvm/src/to_llvm_ir.rs
@@ -2275,8 +2275,7 @@ impl OpToLLVMConstValue for ConstantOp {
         let op = self.get_operation().deref(ctx);
         let value = self.get_value(ctx);
         if let Some(const_val) = attr_cast::<dyn AttrToLLVMConst>(&*value) {
-            let const_val = const_val.convert(ctx, llvm_ctx, cctx)?;
-            Ok(const_val)
+            const_val.convert(ctx, llvm_ctx, cctx)
         } else {
             input_err!(op.loc(), ToLLVMErr::ConstOpNotConstVal)
         }

--- a/pliron-llvm/src/to_llvm_ir.rs
+++ b/pliron-llvm/src/to_llvm_ir.rs
@@ -162,8 +162,8 @@ pub enum ToLLVMErr {
     UndefinedBlock(String),
     #[error("Number of block args in the source dialect equal the number of PHIs in target IR")]
     NumBlockArgsNumPhisMismatch,
-    #[error("ConstantOp must have integer or float value")]
-    ConstOpNotIntOrFloat,
+    #[error("ConstantOp value must implement AttrToLLVMConst")]
+    ConstOpNotConstVal,
     #[error(
         "Insert/Extract value instructions must specify exactly one index, an LLVM-C API limitation"
     )]
@@ -2274,19 +2274,11 @@ impl OpToLLVMConstValue for ConstantOp {
     ) -> Result<LLVMValue> {
         let op = self.get_operation().deref(ctx);
         let value = self.get_value(ctx);
-        if let Some(int_val) = value.downcast_ref::<IntegerAttr>() {
-            let int_ty = int_val.get_type();
-            let int_ty_llvm = convert_type(ctx, llvm_ctx, cctx, int_ty.into())?;
-            let ap_int_val: APInt = int_val.clone().into();
-            let const_val = llvm_const_int(int_ty_llvm, ap_int_val.to_u64(), false);
-            Ok(const_val)
-        } else if let Some(float_val) = attr_cast::<dyn FloatAttrToFP64>(&*value) {
-            let float_ty = float_val.get_type(ctx);
-            let float_ty_llvm = convert_type(ctx, llvm_ctx, cctx, float_ty)?;
-            let const_val = llvm_const_real(float_ty_llvm, float_val.to_fp64());
+        if let Some(const_val) = attr_cast::<dyn AttrToLLVMConst>(&*value) {
+            let const_val = const_val.convert(ctx, llvm_ctx, cctx)?;
             Ok(const_val)
         } else {
-            input_err!(op.loc(), ToLLVMErr::ConstOpNotIntOrFloat)
+            input_err!(op.loc(), ToLLVMErr::ConstOpNotConstVal)
         }
     }
 }


### PR DESCRIPTION
## Description

The logic for conversion was previously duplicated in both `AttrToLLVMConst` and `OpToLLVMConstValue`

Also add missing `#[attr_interface_impl]` for `ZeroAttr`, `UndefAttr` and `PoisonAttr`