### PR TITLE
chore: ignore local development files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
 /target
 Cargo.lock
+
+# OS files
+.DS_Store
+
+# IDEs and editors
+.idea/
+*.iml
+.vscode/
+.cursor/


### PR DESCRIPTION
## Description

Ignore common local development files generated by operating systems, IDEs, editors, and local AI tooling.

This keeps the working tree clean without affecting project sources or build artifacts.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] A human is involved in writing this PR description and will handle review interactions, per our [AI tool policy](../CONTRIBUTING.md).
- [x] I understand every part of this change (including any AI-generated code) and can explain the reasoning behind it.
- [x] Intrusive / large changes were discussed on Discord before this PR.
- [x] `pre-ci.sh` passes locally.