### PR TITLE
[pliron-llvm]: Add packed struct type support

### DIFF
--- a/pliron-llvm/src/from_llvm_ir.rs
+++ b/pliron-llvm/src/from_llvm_ir.rs
@@ -70,7 +70,7 @@ use crate::{
         llvm_get_struct_name, llvm_get_switch_case_value, llvm_get_type_kind, llvm_get_value_kind,
         llvm_get_value_name, llvm_get_vector_size, llvm_global_get_value_type, llvm_is_a,
         llvm_is_declaration, llvm_is_function_type_var_arg, llvm_is_opaque_struct,
-        llvm_lookup_intrinsic_id, llvm_print_value_to_string, llvm_type_of,
+        llvm_is_packed_struct, llvm_lookup_intrinsic_id, llvm_print_value_to_string, llvm_type_of,
         llvm_value_as_basic_block, llvm_value_is_basic_block, param_iter,
     },
     op_interfaces::{
@@ -89,8 +89,8 @@ use crate::{
         UndefOp, UnreachableOp, VAArgOp, XorOp, ZExtOp, ZeroOp,
     },
     types::{
-        ArrayType, FuncType, PointerType, StructErr, StructType, VectorType, VectorTypeKind,
-        VoidType,
+        ArrayType, FuncType, PointerType, StructErr, StructLayout, StructType, VectorType,
+        VectorTypeKind, VoidType,
     },
 };
 
@@ -266,20 +266,22 @@ fn convert_type(ctx: &Context, cctx: &mut ConversionContext, ty: LLVMType) -> Re
             let name_opt: Option<Identifier> =
                 llvm_get_struct_name(ty).map(|str| cctx.id_legaliser.legalise(&str));
             if llvm_is_opaque_struct(ty) {
-                // Opaque structs must be named.
+                // Opaque structs must be named. Layout is a body property,
+                // so use the default until the body is defined.
                 let Some(name) = name_opt else {
                     return input_err_noloc!(StructErr::OpaqueAndAnonymousErr);
                 };
-                Ok(StructType::get_named(ctx, name, None)?.into())
+                Ok(StructType::get_named(ctx, name, None, StructLayout::default())?.into())
             } else {
+                let layout: StructLayout = llvm_is_packed_struct(ty).into();
                 let field_types = llvm_get_struct_element_types(ty)
                     .into_iter()
                     .map(|ty| convert_type(ctx, cctx, ty))
                     .collect::<Result<_>>()?;
                 if let Some(name) = name_opt {
-                    Ok(StructType::get_named(ctx, name, Some(field_types))?.into())
+                    Ok(StructType::get_named(ctx, name, Some(field_types), layout)?.into())
                 } else {
-                    Ok(StructType::get_unnamed(ctx, field_types).into())
+                    Ok(StructType::get_unnamed(ctx, field_types, layout).into())
                 }
             }
         }

--- a/pliron-llvm/src/from_llvm_ir.rs
+++ b/pliron-llvm/src/from_llvm_ir.rs
@@ -266,12 +266,11 @@ fn convert_type(ctx: &Context, cctx: &mut ConversionContext, ty: LLVMType) -> Re
             let name_opt: Option<Identifier> =
                 llvm_get_struct_name(ty).map(|str| cctx.id_legaliser.legalise(&str));
             if llvm_is_opaque_struct(ty) {
-                // Opaque structs must be named. Layout is a body property,
-                // so use the default until the body is defined.
+                // Opaque structs must be named.
                 let Some(name) = name_opt else {
                     return input_err_noloc!(StructErr::OpaqueAndAnonymousErr);
                 };
-                Ok(StructType::get_named(ctx, name, None, StructLayout::default())?.into())
+                Ok(StructType::get_named(ctx, name, None)?.into())
             } else {
                 let layout: StructLayout = llvm_is_packed_struct(ty).into();
                 let field_types = llvm_get_struct_element_types(ty)
@@ -279,9 +278,9 @@ fn convert_type(ctx: &Context, cctx: &mut ConversionContext, ty: LLVMType) -> Re
                     .map(|ty| convert_type(ctx, cctx, ty))
                     .collect::<Result<_>>()?;
                 if let Some(name) = name_opt {
-                    Ok(StructType::get_named(ctx, name, Some(field_types), layout)?.into())
+                    Ok(StructType::get_named(ctx, name, Some((field_types, layout)))?.into())
                 } else {
-                    Ok(StructType::get_unnamed(ctx, field_types, layout).into())
+                    Ok(StructType::get_unnamed(ctx, (field_types, layout)).into())
                 }
             }
         }

--- a/pliron-llvm/src/llvm_sys/core.rs
+++ b/pliron-llvm/src/llvm_sys/core.rs
@@ -60,14 +60,14 @@ use llvm_sys::{
         LLVMGlobalGetValueType, LLVMHalfTypeInContext, LLVMInstructionEraseFromParent,
         LLVMIntTypeInContext, LLVMIntrinsicIsOverloaded, LLVMIsAFunction, LLVMIsATerminatorInst,
         LLVMIsAUser, LLVMIsConstantString, LLVMIsDeclaration, LLVMIsFunctionVarArg,
-        LLVMIsOpaqueStruct, LLVMLookupIntrinsicID, LLVMModuleCreateWithNameInContext,
-        LLVMPointerTypeInContext, LLVMPositionBuilderAtEnd, LLVMPositionBuilderBefore,
-        LLVMPrintModuleToFile, LLVMPrintModuleToString, LLVMPrintTypeToString,
-        LLVMPrintValueToString, LLVMReplaceAllUsesWith, LLVMScalableVectorType, LLVMSetAlignment,
-        LLVMSetFastMathFlags, LLVMSetInitializer, LLVMSetLinkage, LLVMSetNNeg,
-        LLVMStructCreateNamed, LLVMStructSetBody, LLVMStructTypeInContext, LLVMTypeIsSized,
-        LLVMTypeOf, LLVMValueAsBasicBlock, LLVMValueIsBasicBlock, LLVMVectorType,
-        LLVMVoidTypeInContext,
+        LLVMIsOpaqueStruct, LLVMIsPackedStruct, LLVMLookupIntrinsicID,
+        LLVMModuleCreateWithNameInContext, LLVMPointerTypeInContext, LLVMPositionBuilderAtEnd,
+        LLVMPositionBuilderBefore, LLVMPrintModuleToFile, LLVMPrintModuleToString,
+        LLVMPrintTypeToString, LLVMPrintValueToString, LLVMReplaceAllUsesWith,
+        LLVMScalableVectorType, LLVMSetAlignment, LLVMSetFastMathFlags, LLVMSetInitializer,
+        LLVMSetLinkage, LLVMSetNNeg, LLVMStructCreateNamed, LLVMStructSetBody,
+        LLVMStructTypeInContext, LLVMTypeIsSized, LLVMTypeOf, LLVMValueAsBasicBlock,
+        LLVMValueIsBasicBlock, LLVMVectorType, LLVMVoidTypeInContext,
     },
     error::{LLVMDisposeErrorMessage, LLVMErrorRef, LLVMGetErrorMessage},
     prelude::{
@@ -689,6 +689,12 @@ pub fn llvm_get_pointer_address_space(ty: LLVMType) -> u32 {
 pub fn llvm_is_opaque_struct(ty: LLVMType) -> bool {
     assert!(llvm_get_type_kind(ty) == LLVMTypeKind::LLVMStructTypeKind);
     unsafe { LLVMIsOpaqueStruct(ty.into()) }.to_bool()
+}
+
+/// LLVMIsPackedStruct
+pub fn llvm_is_packed_struct(ty: LLVMType) -> bool {
+    assert!(llvm_get_type_kind(ty) == LLVMTypeKind::LLVMStructTypeKind);
+    unsafe { LLVMIsPackedStruct(ty.into()) }.to_bool()
 }
 
 /// LLVMCountStructElementTypes

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -73,7 +73,7 @@ use crate::{
         func_op_attr_names::ATTR_KEY_LLVM_FUNC_TYPE,
         global_op_attr_names::{ATTR_KEY_GLOBAL_INITIALIZER, ATTR_KEY_LLVM_GLOBAL_TYPE},
     },
-    types::{ArrayType, FuncType, StructType, VectorType},
+    types::{ArrayType, FuncType, StructLayout, StructType, VectorType},
 };
 
 #[cfg(feature = "llvm-sys")]
@@ -1812,7 +1812,9 @@ impl AtomicCmpxchgOp {
         use pliron::r#type::Typed;
         let val_ty = cmp.get_type(ctx);
         let bool_ty = IntegerType::get(ctx, 1, Signedness::Signless);
-        let res_ty = StructType::get_unnamed(ctx, vec![val_ty, bool_ty.into()]).into();
+        let res_ty =
+            StructType::get_unnamed(ctx, vec![val_ty, bool_ty.into()], StructLayout::Unpacked)
+                .into();
         let op = Operation::new(
             ctx,
             Self::get_concrete_op_info(),

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -1813,7 +1813,7 @@ impl AtomicCmpxchgOp {
         let val_ty = cmp.get_type(ctx);
         let bool_ty = IntegerType::get(ctx, 1, Signedness::Signless);
         let res_ty =
-            StructType::get_unnamed(ctx, (vec![val_ty, bool_ty.into()], StructLayout::default()))
+            StructType::get_unnamed(ctx, (vec![val_ty, bool_ty.into()], StructLayout::Unpacked))
                 .into();
         let op = Operation::new(
             ctx,

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -1813,7 +1813,7 @@ impl AtomicCmpxchgOp {
         let val_ty = cmp.get_type(ctx);
         let bool_ty = IntegerType::get(ctx, 1, Signedness::Signless);
         let res_ty =
-            StructType::get_unnamed(ctx, vec![val_ty, bool_ty.into()], StructLayout::Unpacked)
+            StructType::get_unnamed(ctx, (vec![val_ty, bool_ty.into()], StructLayout::default()))
                 .into();
         let op = Operation::new(
             ctx,

--- a/pliron-llvm/src/to_llvm_ir.rs
+++ b/pliron-llvm/src/to_llvm_ir.rs
@@ -394,18 +394,23 @@ impl ToLLVMType for StructType {
                 .fields()
                 .map(|fty| convert_type(ctx, llvm_ctx, cctx, fty))
                 .collect::<Result<Vec<_>>>()?;
+            let is_packed: bool = self.layout().into();
             if let Some(name) = self.name() {
                 match cctx.structs_map.entry(name) {
                     htable::Entry::Occupied(entry) => Ok(*entry.get()),
                     htable::Entry::Vacant(entry) => {
                         let str_ty = llvm_struct_create_named(llvm_ctx, entry.key().as_ref());
-                        llvm_struct_set_body(str_ty, &field_types, false);
+                        llvm_struct_set_body(str_ty, &field_types, is_packed);
                         entry.insert(str_ty);
                         Ok(str_ty)
                     }
                 }
             } else {
-                Ok(llvm_struct_type_in_context(llvm_ctx, &field_types, false))
+                Ok(llvm_struct_type_in_context(
+                    llvm_ctx,
+                    &field_types,
+                    is_packed,
+                ))
             }
         }
     }

--- a/pliron-llvm/src/types.rs
+++ b/pliron-llvm/src/types.rs
@@ -27,6 +27,31 @@ use pliron::{
 };
 use thiserror::Error;
 
+/// Layout of an LLVM struct type.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+#[format]
+pub enum StructLayout {
+    #[default]
+    Unpacked,
+    Packed,
+}
+
+impl From<bool> for StructLayout {
+    fn from(is_packed: bool) -> Self {
+        if is_packed {
+            Self::Packed
+        } else {
+            Self::Unpacked
+        }
+    }
+}
+
+impl From<StructLayout> for bool {
+    fn from(layout: StructLayout) -> Self {
+        layout == StructLayout::Packed
+    }
+}
+
 /// Represents a c-like struct type.
 /// Limitations and warnings on its usage are similar to that in MLIR.
 /// `<https://mlir.llvm.org/docs/Dialects/LLVM/#structure-types>`
@@ -42,58 +67,61 @@ use thiserror::Error;
 pub struct StructType {
     name: Option<Identifier>,
     fields: Option<Vec<TypeHandle>>,
+    layout: StructLayout,
 }
 
 impl StructType {
-    /// Get or create a named StructType.
+    /// Get or create a named StructType with the provided layout.
     /// If `fields` is `None`, it indicates an opaque struct.
     /// A body can be added to opaque structs by calling this again later.
-    /// Returns an error if all of the below conditions are true:
-    ///   a. The name is already registered
-    ///   b. The body is already set (i.e, the struct is not oqaue)
-    ///   c. The fields provided here don't match with the existing body.
-    /// Since named structs only rely on the name for uniqueness,
-    /// It is not an error to provide `fields` as `None` even when
-    /// the named struct already exists and has its body set.
     pub fn get_named(
         ctx: &Context,
         name: Identifier,
         fields: Option<Vec<TypeHandle>>,
+        layout: StructLayout,
     ) -> Result<TypedHandle<Self>> {
         let self_handle = Type::instantiate(
             StructType {
                 name: Some(name.clone()),
-                // Uniquing happens only on the name, so this doesn't matter.
+                // Named structs are uniqued only by name. Layout is a body property,
+                // so opaque structs use the default until their body is defined.
                 fields: None,
+                layout: StructLayout::default(),
             },
             ctx,
         );
+
         // Verify that we created a new or equivalent existing type.
         let mut self_ref = self_handle.to_handle().deref_mut(ctx);
         let self_ref = self_ref.downcast_mut::<StructType>().unwrap();
         assert!(self_ref.name.as_ref().unwrap() == &name);
         if let Some(fields) = fields {
-            // We've been provided fields to be set.
             if let Some(existing_fields) = &self_ref.fields {
-                // Fields were already set before, ensure they're same as the given ones.
-                if existing_fields != &fields {
+                // The body was already set. Both its fields and layout must match.
+                if existing_fields != &fields || self_ref.layout != layout {
                     input_err_noloc!(StructErr::ExistingMismatch(name.into()))?
                 }
             } else {
-                // Set the fields now.
+                // Set the body now, including its layout.
                 self_ref.fields = Some(fields);
+                self_ref.layout = layout;
             }
         }
         Ok(self_handle)
     }
 
     /// Get or create a new unnamed (anonymous) struct.
-    /// These are finalized upon creation, and uniqued based on the fields.
-    pub fn get_unnamed(ctx: &Context, fields: Vec<TypeHandle>) -> TypedHandle<Self> {
+    /// These are finalized upon creation and uniqued based on fields and layout.
+    pub fn get_unnamed(
+        ctx: &Context,
+        fields: Vec<TypeHandle>,
+        layout: StructLayout,
+    ) -> TypedHandle<Self> {
         Type::instantiate(
             StructType {
                 name: None,
                 fields: Some(fields),
+                layout,
             },
             ctx,
         )
@@ -102,6 +130,11 @@ impl StructType {
     /// Does this struct not have its body set?
     pub fn is_opaque(&self) -> bool {
         self.fields.is_none()
+    }
+
+    /// Get this struct's layout.
+    pub fn layout(&self) -> StructLayout {
+        self.layout
     }
 
     /// Is this a named struct?
@@ -196,7 +229,8 @@ impl Printable for StructType {
         state: &printable::State,
         f: &mut core::fmt::Formatter<'_>,
     ) -> core::fmt::Result {
-        write!(f, "<")?;
+        self.layout.fmt(ctx, state, f)?;
+        write!(f, " <")?;
 
         if let Some(name) = &self.name {
             if struct_type_start_printing(state, name) {
@@ -230,14 +264,13 @@ impl Hash for StructType {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         match &self.name {
             Some(name) => name.hash(state),
-            None => self
-                .fields
-                .as_ref()
-                .expect("Anonymous struct must have its fields set")
-                .iter()
-                .for_each(|field_type| {
-                    field_type.hash(state);
-                }),
+            None => {
+                self.fields
+                    .as_ref()
+                    .expect("Anonymous struct must have its fields set")
+                    .hash(state);
+                self.layout.hash(state);
+            }
         }
     }
 }
@@ -246,7 +279,7 @@ impl PartialEq for StructType {
     fn eq(&self, other: &Self) -> bool {
         match (&self.name, &other.name) {
             (Some(name), Some(other_name)) => name == other_name,
-            (None, None) => self.fields == other.fields,
+            (None, None) => self.fields == other.fields && self.layout == other.layout,
             _ => false,
         }
     }
@@ -274,13 +307,18 @@ impl Parsable for StructType {
         let anonymous = spaced((location(), body_parser()))
             .map(|(loc, body)| (loc, None::<Identifier>, Some(body)));
 
-        // A struct type is named or anonymous.
-        let mut struct_parser = between(token('<'), token('>'), named.or(anonymous));
+        // A struct type always starts with an explicit layout.
+        let mut struct_parser = spaced(StructLayout::parser(())).and(between(
+            token('<'),
+            token('>'),
+            named.or(anonymous),
+        ));
 
-        let (loc, name_opt, body_opt) = struct_parser.parse_stream(state_stream).into_result()?.0;
+        let (layout, (loc, name_opt, body_opt)) =
+            struct_parser.parse_stream(state_stream).into_result()?.0;
         let ctx = &mut state_stream.state.ctx;
         if let Some(name) = name_opt {
-            StructType::get_named(ctx, name, body_opt)
+            StructType::get_named(ctx, name, body_opt, layout)
                 .map_err(|mut err| {
                     err.set_loc(loc);
                     err
@@ -290,6 +328,7 @@ impl Parsable for StructType {
             Ok(StructType::get_unnamed(
                 ctx,
                 body_opt.expect("Without a name, a struct type must have a body."),
+                layout,
             ))
             .into_parse_result()
         }
@@ -438,7 +477,7 @@ mod tests {
 
     use alloc::{format, string::ToString, vec};
 
-    use crate::types::{FuncType, PointerType, StructType, VoidType};
+    use crate::types::{FuncType, PointerType, StructLayout, StructType, VoidType};
     use expect_test::expect;
     use pliron::{
         builtin::types::{IntegerType, Signedness},
@@ -461,7 +500,8 @@ mod tests {
 
         // Create an opaque struct since we want a recursive type.
         let list_struct: TypeHandle =
-            StructType::get_named(&ctx, linked_list_id.clone(), None)?.into();
+            StructType::get_named(&ctx, linked_list_id.clone(), None, StructLayout::Unpacked)?
+                .into();
         assert!(
             list_struct
                 .deref(&ctx)
@@ -472,7 +512,12 @@ mod tests {
         let list_struct_ptr = TypedPointerType::get(&ctx, list_struct).into();
         let fields = vec![int64, list_struct_ptr];
         // Set the struct body now.
-        StructType::get_named(&ctx, linked_list_id.clone(), Some(fields))?;
+        StructType::get_named(
+            &ctx,
+            linked_list_id.clone(),
+            Some(fields),
+            StructLayout::Unpacked,
+        )?;
         assert!(
             !list_struct
                 .deref(&ctx)
@@ -481,20 +526,78 @@ mod tests {
                 .is_opaque()
         );
 
-        let list_struct_2 = StructType::get_named(&ctx, linked_list_id, None)
-            .unwrap()
-            .into();
+        let list_struct_2 =
+            StructType::get_named(&ctx, linked_list_id, None, StructLayout::Unpacked)?.into();
         assert!(list_struct == list_struct_2);
 
         assert_eq!(
             list_struct.disp(&ctx).to_string(),
-            "llvm.struct <LinkedList { builtin.integer i64, llvm.typed_ptr <llvm.struct <LinkedList>> }>"
+            "llvm.struct Unpacked <LinkedList { builtin.integer i64, llvm.typed_ptr <llvm.struct Unpacked <LinkedList>> }>"
         );
 
         let head_fields = vec![int64, list_struct_ptr];
-        let head_struct = StructType::get_unnamed(&ctx, head_fields.clone());
-        let head_struct2 = StructType::get_unnamed(&ctx, head_fields);
+        let head_struct =
+            StructType::get_unnamed(&ctx, head_fields.clone(), StructLayout::Unpacked);
+        let head_struct2 = StructType::get_unnamed(&ctx, head_fields, StructLayout::Unpacked);
         assert!(head_struct == head_struct2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_struct_packedness() -> Result<()> {
+        let ctx = Context::new();
+        let int8: TypeHandle = IntegerType::get(&ctx, 8, Signedness::Signless).into();
+        let int32: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Signless).into();
+        let fields = vec![int8, int32];
+
+        assert_eq!(StructLayout::default(), StructLayout::Unpacked);
+        assert_eq!(StructLayout::from(false), StructLayout::Unpacked);
+        assert_eq!(StructLayout::from(true), StructLayout::Packed);
+        assert!(!bool::from(StructLayout::Unpacked));
+        assert!(bool::from(StructLayout::Packed));
+
+        let unpacked = StructType::get_unnamed(&ctx, fields.clone(), StructLayout::Unpacked);
+        let packed = StructType::get_unnamed(&ctx, fields.clone(), StructLayout::Packed);
+        let packed_again = StructType::get_unnamed(&ctx, fields.clone(), StructLayout::Packed);
+        assert!(unpacked != packed);
+        assert!(packed == packed_again);
+        assert_eq!(
+            packed
+                .to_handle()
+                .deref(&ctx)
+                .downcast_ref::<StructType>()
+                .unwrap()
+                .layout(),
+            StructLayout::Packed
+        );
+
+        // Named structs remain uniqued by name. Layout is part of body
+        // consistency and may be established after creating an opaque struct.
+        let name: Identifier = "PackedNamed".try_into().unwrap();
+        let named = StructType::get_named(&ctx, name.clone(), None, StructLayout::Unpacked)?;
+        StructType::get_named(
+            &ctx,
+            name.clone(),
+            Some(fields.clone()),
+            StructLayout::Packed,
+        )?;
+        assert_eq!(
+            named
+                .to_handle()
+                .deref(&ctx)
+                .downcast_ref::<StructType>()
+                .unwrap()
+                .layout(),
+            StructLayout::Packed
+        );
+        StructType::get_named(
+            &ctx,
+            name.clone(),
+            Some(fields.clone()),
+            StructLayout::Packed,
+        )?;
+        assert!(StructType::get_named(&ctx, name, Some(fields), StructLayout::Unpacked).is_err());
 
         Ok(())
     }
@@ -635,32 +738,56 @@ mod tests {
         let res = parse_from_str(
             type_parser(),
             &mut ctx,
-            "llvm.struct <LinkedList { builtin.integer i64, llvm.typed_ptr <llvm.struct <LinkedList>> }>",
+            "llvm.struct Unpacked <LinkedList { builtin.integer i64, llvm.typed_ptr <llvm.struct Unpacked <LinkedList>> }>",
         )
         .expect_ok(&ctx);
         assert_eq!(
             &res.disp(&ctx).to_string(),
-            "llvm.struct <LinkedList { builtin.integer i64, llvm.typed_ptr <llvm.struct <LinkedList>> }>"
+            "llvm.struct Unpacked <LinkedList { builtin.integer i64, llvm.typed_ptr <llvm.struct Unpacked <LinkedList>> }>"
         );
 
         // Test parsing an opaque struct.
-        let test_string = "llvm.struct <ExternStruct>";
+        let test_string = "llvm.struct Unpacked <ExternStruct>";
         let res = parse_from_str(type_parser(), &mut ctx, test_string).expect_ok(&ctx);
         assert_eq!(&res.disp(&ctx).to_string(), test_string);
         {
             let res = res.deref(&ctx);
             let res = res.downcast_ref::<StructType>().unwrap();
             assert!(res.is_opaque() && res.is_named());
+            assert_eq!(res.layout(), StructLayout::Unpacked);
         }
 
-        // Test parsing an unnamed struct.
-        let test_string = "llvm.struct <{ builtin.integer i8 }>";
+        // Test parsing an unpacked unnamed struct.
+        let test_string = "llvm.struct Unpacked <{ builtin.integer i8 }>";
         let res = parse_from_str(type_parser(), &mut ctx, test_string).expect_ok(&ctx);
         assert_eq!(&res.disp(&ctx).to_string(), test_string);
         {
             let res = res.deref(&ctx);
             let res = res.downcast_ref::<StructType>().unwrap();
             assert!(!res.is_opaque() && !res.is_named());
+            assert_eq!(res.layout(), StructLayout::Unpacked);
+        }
+
+        // Test parsing a packed unnamed struct.
+        let test_string = "llvm.struct Packed <{ builtin.integer i8 }>";
+        let res = parse_from_str(type_parser(), &mut ctx, test_string).expect_ok(&ctx);
+        assert_eq!(&res.disp(&ctx).to_string(), test_string);
+        {
+            let res = res.deref(&ctx);
+            let res = res.downcast_ref::<StructType>().unwrap();
+            assert!(!res.is_opaque() && !res.is_named());
+            assert_eq!(res.layout(), StructLayout::Packed);
+        }
+
+        // Test parsing a packed named struct.
+        let test_string = "llvm.struct Packed <Packed { builtin.integer i8 }>";
+        let res = parse_from_str(type_parser(), &mut ctx, test_string).expect_ok(&ctx);
+        assert_eq!(&res.disp(&ctx).to_string(), test_string);
+        {
+            let res = res.deref(&ctx);
+            let res = res.downcast_ref::<StructType>().unwrap();
+            assert!(!res.is_opaque() && res.is_named());
+            assert_eq!(res.layout(), StructLayout::Packed);
         }
     }
 
@@ -671,7 +798,7 @@ mod tests {
         let _ = parse_from_str(
             type_parser(),
             &mut ctx,
-            "llvm.struct < My1 { builtin.integer i8 } >",
+            "llvm.struct Unpacked < My1 { builtin.integer i8 } >",
         )
         .expect_ok(&ctx);
 
@@ -680,14 +807,14 @@ mod tests {
             parse_from_str(
                 type_parser(),
                 &mut ctx,
-                "llvm.struct < My1 { builtin.integer i16 } >",
+                "llvm.struct Unpacked < My1 { builtin.integer i16 } >",
             )
             .unwrap_err()
         );
 
         let expected_err_msg = expect![[r#"
             Compilation error: invalid input program.
-            Parse error at line: 1, column: 15
+            Parse error at line: 1, column: 24
             struct My1 already exists and is different
         "#]];
         expected_err_msg.assert_eq(&err_msg);

--- a/pliron-llvm/src/types.rs
+++ b/pliron-llvm/src/types.rs
@@ -61,80 +61,72 @@ impl From<StructLayout> for bool {
 ///      named structs as identified structs.
 ///   4. Named structs may be opaque, i.e., no body specificed.
 ///      Recursive types may be created by first creating an opaque struct
-///      and later setting its fields (body).
+///      and later setting its body.
 #[pliron_type(name = "llvm.struct")]
 #[derive(Debug)]
 pub struct StructType {
     name: Option<Identifier>,
-    fields: Option<Vec<TypeHandle>>,
-    layout: StructLayout,
+    body: Option<(Vec<TypeHandle>, StructLayout)>,
 }
 
 impl StructType {
-    /// Get or create a named StructType with the provided layout.
-    /// If `fields` is `None`, it indicates an opaque struct.
+    /// Get or create a named StructType.
+    /// If `body` is `None`, it indicates an opaque struct.
     /// A body can be added to opaque structs by calling this again later.
+    /// Returns an error if all of the below conditions are true:
+    ///   a. The name is already registered
+    ///   b. The body is already set (i.e, the struct is not oqaue)
+    ///   c. The body provided here don't match with the existing body.
+    /// Since named structs only rely on the name for uniqueness,
+    /// It is not an error to provide `body` as `None` even when
+    /// the named struct already exists and has its body set.
     pub fn get_named(
         ctx: &Context,
         name: Identifier,
-        fields: Option<Vec<TypeHandle>>,
-        layout: StructLayout,
+        body: Option<(Vec<TypeHandle>, StructLayout)>,
     ) -> Result<TypedHandle<Self>> {
         let self_handle = Type::instantiate(
             StructType {
                 name: Some(name.clone()),
-                // Named structs are uniqued only by name. Layout is a body property,
-                // so opaque structs use the default until their body is defined.
-                fields: None,
-                layout: StructLayout::default(),
+                // Uniquing happens only on the name, so this doesn't matter.
+                body: None,
             },
             ctx,
         );
-
         // Verify that we created a new or equivalent existing type.
         let mut self_ref = self_handle.to_handle().deref_mut(ctx);
         let self_ref = self_ref.downcast_mut::<StructType>().unwrap();
         assert!(self_ref.name.as_ref().unwrap() == &name);
-        if let Some(fields) = fields {
-            if let Some(existing_fields) = &self_ref.fields {
-                // The body was already set. Both its fields and layout must match.
-                if existing_fields != &fields || self_ref.layout != layout {
+        if let Some(body) = body {
+            // We've been provided body to be set.
+            if let Some(existing_body) = &self_ref.body {
+                // Body was already set before, ensure it's same as the given one.
+                if existing_body != &body {
                     input_err_noloc!(StructErr::ExistingMismatch(name.into()))?
                 }
             } else {
-                // Set the body now, including its layout.
-                self_ref.fields = Some(fields);
-                self_ref.layout = layout;
+                // Set the body now.
+                self_ref.body = Some(body);
             }
         }
         Ok(self_handle)
     }
 
     /// Get or create a new unnamed (anonymous) struct.
-    /// These are finalized upon creation and uniqued based on fields and layout.
-    pub fn get_unnamed(
-        ctx: &Context,
-        fields: Vec<TypeHandle>,
-        layout: StructLayout,
-    ) -> TypedHandle<Self> {
+    /// These are finalized upon creation, and uniqued based on the fields and layout.
+    pub fn get_unnamed(ctx: &Context, body: (Vec<TypeHandle>, StructLayout)) -> TypedHandle<Self> {
         Type::instantiate(
             StructType {
                 name: None,
-                fields: Some(fields),
-                layout,
+                body: Some(body),
             },
             ctx,
         )
     }
 
-    /// Does this struct not have its body set?
+    /// A struct without a body set is opaque
     pub fn is_opaque(&self) -> bool {
-        self.fields.is_none()
-    }
-
-    /// Get this struct's layout.
-    pub fn layout(&self) -> StructLayout {
-        self.layout
+        self.body.is_none()
     }
 
     /// Is this a named struct?
@@ -147,26 +139,45 @@ impl StructType {
         self.name.clone()
     }
 
-    /// Get type of the idx'th field.
-    pub fn field_type(&self, field_idx: usize) -> TypeHandle {
-        self.fields
+    /// Get this struct's layout.
+    ///
+    /// **Panics** if the struct is opaque.
+    pub fn layout(&self) -> StructLayout {
+        self.body
             .as_ref()
-            .expect("field_type shouldn't be called on opaque types")[field_idx]
+            .expect("layout shouldn't be called on opaque types")
+            .1
+    }
+
+    /// Get type of the idx'th field.
+    ///
+    /// **Panics** if the struct is opaque or the index is invalid.
+    pub fn field_type(&self, field_idx: usize) -> TypeHandle {
+        self.body
+            .as_ref()
+            .expect("field_type shouldn't be called on opaque types")
+            .0[field_idx]
     }
 
     /// Get the number of fields this struct has
+    ///
+    /// **Panics** if the struct is opaque.
     pub fn num_fields(&self) -> usize {
-        self.fields
+        self.body
             .as_ref()
             .expect("num_fields shouldn't be called on opaque types")
+            .0
             .len()
     }
 
-    /// Get an iterator over the fields of this struct
+    /// Get an iterator over the fields of this struct.
+    ///
+    /// **Panics** if the struct is opaque.
     pub fn fields(&self) -> impl Iterator<Item = TypeHandle> + '_ {
-        self.fields
+        self.body
             .as_ref()
             .expect("fields shouldn't be called on opaque types")
+            .0
             .iter()
             .cloned()
     }
@@ -182,7 +193,7 @@ pub enum StructErr {
 
 impl Verify for StructType {
     fn verify(&self, _ctx: &Context) -> Result<()> {
-        if self.name.is_none() && self.fields.is_none() {
+        if self.name.is_none() && self.body.is_none() {
             verify_err_noloc!(StructErr::OpaqueAndAnonymousErr)?
         }
         Ok(())
@@ -229,8 +240,7 @@ impl Printable for StructType {
         state: &printable::State,
         f: &mut core::fmt::Formatter<'_>,
     ) -> core::fmt::Result {
-        self.layout.fmt(ctx, state, f)?;
-        write!(f, " <")?;
+        write!(f, "<")?;
 
         if let Some(name) = &self.name {
             if struct_type_start_printing(state, name) {
@@ -243,13 +253,14 @@ impl Printable for StructType {
             }
         }
 
-        if let Some(fields) = &self.fields {
+        if let Some((fields, layout)) = &self.body {
             enclosed(
                 "{ ",
                 " }",
                 list_with_sep(fields, ListSeparator::CharSpace(',')),
             )
             .fmt(ctx, state, f)?;
+            write!(f, " : {}", layout.disp(ctx))?;
         }
 
         // Done processing this struct. Remove it from the stack.
@@ -265,11 +276,10 @@ impl Hash for StructType {
         match &self.name {
             Some(name) => name.hash(state),
             None => {
-                self.fields
+                self.body
                     .as_ref()
-                    .expect("Anonymous struct must have its fields set")
+                    .expect("Anonymous struct must have its body set")
                     .hash(state);
-                self.layout.hash(state);
             }
         }
     }
@@ -279,7 +289,7 @@ impl PartialEq for StructType {
     fn eq(&self, other: &Self) -> bool {
         match (&self.name, &other.name) {
             (Some(name), Some(other_name)) => name == other_name,
-            (None, None) => self.fields == other.fields && self.layout == other.layout,
+            (None, None) => self.body == other.body,
             _ => false,
         }
     }
@@ -299,6 +309,8 @@ impl Parsable for StructType {
         let body_parser = || {
             // Parse multiple type annotated fields separated by ',', all of it delimited by braces.
             delimited_list_parser('{', '}', ',', type_parser())
+                // followed by the layout
+                .and(spaced(token(':')).with(spaced(StructLayout::parser(()))))
         };
 
         let named = spaced((location(), Identifier::parser(())))
@@ -307,18 +319,13 @@ impl Parsable for StructType {
         let anonymous = spaced((location(), body_parser()))
             .map(|(loc, body)| (loc, None::<Identifier>, Some(body)));
 
-        // A struct type always starts with an explicit layout.
-        let mut struct_parser = spaced(StructLayout::parser(())).and(between(
-            token('<'),
-            token('>'),
-            named.or(anonymous),
-        ));
+        // A struct type is named or anonymous.
+        let mut struct_parser = between(token('<'), token('>'), named.or(anonymous));
 
-        let (layout, (loc, name_opt, body_opt)) =
-            struct_parser.parse_stream(state_stream).into_result()?.0;
+        let (loc, name_opt, body_opt) = struct_parser.parse_stream(state_stream).into_result()?.0;
         let ctx = &mut state_stream.state.ctx;
         if let Some(name) = name_opt {
-            StructType::get_named(ctx, name, body_opt, layout)
+            StructType::get_named(ctx, name, body_opt)
                 .map_err(|mut err| {
                     err.set_loc(loc);
                     err
@@ -328,7 +335,6 @@ impl Parsable for StructType {
             Ok(StructType::get_unnamed(
                 ctx,
                 body_opt.expect("Without a name, a struct type must have a body."),
-                layout,
             ))
             .into_parse_result()
         }
@@ -500,8 +506,7 @@ mod tests {
 
         // Create an opaque struct since we want a recursive type.
         let list_struct: TypeHandle =
-            StructType::get_named(&ctx, linked_list_id.clone(), None, StructLayout::Unpacked)?
-                .into();
+            StructType::get_named(&ctx, linked_list_id.clone(), None)?.into();
         assert!(
             list_struct
                 .deref(&ctx)
@@ -515,8 +520,7 @@ mod tests {
         StructType::get_named(
             &ctx,
             linked_list_id.clone(),
-            Some(fields),
-            StructLayout::Unpacked,
+            Some((fields, StructLayout::Unpacked)),
         )?;
         assert!(
             !list_struct
@@ -526,78 +530,58 @@ mod tests {
                 .is_opaque()
         );
 
-        let list_struct_2 =
-            StructType::get_named(&ctx, linked_list_id, None, StructLayout::Unpacked)?.into();
+        // It's okay to get it again without providing the body.
+
+        let list_struct_2 = StructType::get_named(&ctx, linked_list_id.clone(), None)?.into();
         assert!(list_struct == list_struct_2);
 
         assert_eq!(
             list_struct.disp(&ctx).to_string(),
-            "llvm.struct Unpacked <LinkedList { builtin.integer i64, llvm.typed_ptr <llvm.struct Unpacked <LinkedList>> }>"
+            "llvm.struct <LinkedList { builtin.integer i64, llvm.typed_ptr <llvm.struct <LinkedList>> } : Unpacked>"
+        );
+
+        // Re-setting the same body on an already-set named struct is fine.
+        StructType::get_named(
+            &ctx,
+            linked_list_id.clone(),
+            Some((vec![int64, list_struct_ptr], StructLayout::Unpacked)),
+        )?;
+
+        // But changing just the layout, with fields unchanged, is a mismatch.
+        assert!(
+            StructType::get_named(
+                &ctx,
+                linked_list_id.clone(),
+                Some((vec![int64, list_struct_ptr], StructLayout::Packed)),
+            )
+            .is_err()
+        );
+
+        // Or changing just the fields, with layout unchanged, is a mismatch.
+        assert!(
+            StructType::get_named(
+                &ctx,
+                linked_list_id,
+                Some((vec![int64, int64], StructLayout::Unpacked)),
+            )
+            .is_err()
         );
 
         let head_fields = vec![int64, list_struct_ptr];
         let head_struct =
-            StructType::get_unnamed(&ctx, head_fields.clone(), StructLayout::Unpacked);
-        let head_struct2 = StructType::get_unnamed(&ctx, head_fields, StructLayout::Unpacked);
+            StructType::get_unnamed(&ctx, (head_fields.clone(), StructLayout::Unpacked));
+        let head_struct2 =
+            StructType::get_unnamed(&ctx, (head_fields.clone(), StructLayout::Unpacked));
         assert!(head_struct == head_struct2);
 
-        Ok(())
-    }
-
-    #[test]
-    fn test_struct_packedness() -> Result<()> {
-        let ctx = Context::new();
-        let int8: TypeHandle = IntegerType::get(&ctx, 8, Signedness::Signless).into();
-        let int32: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Signless).into();
-        let fields = vec![int8, int32];
-
-        assert_eq!(StructLayout::default(), StructLayout::Unpacked);
-        assert_eq!(StructLayout::from(false), StructLayout::Unpacked);
-        assert_eq!(StructLayout::from(true), StructLayout::Packed);
-        assert!(!bool::from(StructLayout::Unpacked));
-        assert!(bool::from(StructLayout::Packed));
-
-        let unpacked = StructType::get_unnamed(&ctx, fields.clone(), StructLayout::Unpacked);
-        let packed = StructType::get_unnamed(&ctx, fields.clone(), StructLayout::Packed);
-        let packed_again = StructType::get_unnamed(&ctx, fields.clone(), StructLayout::Packed);
-        assert!(unpacked != packed);
-        assert!(packed == packed_again);
+        // Anonymous structs with the same fields but different layout are
+        // distinct types.
+        let head_struct_packed = StructType::get_unnamed(&ctx, (head_fields, StructLayout::Packed));
+        assert!(head_struct != head_struct_packed);
         assert_eq!(
-            packed
-                .to_handle()
-                .deref(&ctx)
-                .downcast_ref::<StructType>()
-                .unwrap()
-                .layout(),
+            head_struct_packed.deref(&ctx).layout(),
             StructLayout::Packed
         );
-
-        // Named structs remain uniqued by name. Layout is part of body
-        // consistency and may be established after creating an opaque struct.
-        let name: Identifier = "PackedNamed".try_into().unwrap();
-        let named = StructType::get_named(&ctx, name.clone(), None, StructLayout::Unpacked)?;
-        StructType::get_named(
-            &ctx,
-            name.clone(),
-            Some(fields.clone()),
-            StructLayout::Packed,
-        )?;
-        assert_eq!(
-            named
-                .to_handle()
-                .deref(&ctx)
-                .downcast_ref::<StructType>()
-                .unwrap()
-                .layout(),
-            StructLayout::Packed
-        );
-        StructType::get_named(
-            &ctx,
-            name.clone(),
-            Some(fields.clone()),
-            StructLayout::Packed,
-        )?;
-        assert!(StructType::get_named(&ctx, name, Some(fields), StructLayout::Unpacked).is_err());
 
         Ok(())
     }
@@ -735,30 +719,23 @@ mod tests {
     fn test_struct_type_parsing() {
         let mut ctx = Context::new();
 
-        let res = parse_from_str(
-            type_parser(),
-            &mut ctx,
-            "llvm.struct Unpacked <LinkedList { builtin.integer i64, llvm.typed_ptr <llvm.struct Unpacked <LinkedList>> }>",
-        )
-        .expect_ok(&ctx);
-        assert_eq!(
-            &res.disp(&ctx).to_string(),
-            "llvm.struct Unpacked <LinkedList { builtin.integer i64, llvm.typed_ptr <llvm.struct Unpacked <LinkedList>> }>"
-        );
+        // Test parsing an unpacked named struct
+        let unpacked_named = "llvm.struct <LinkedList { builtin.integer i64, llvm.typed_ptr <llvm.struct <LinkedList>> } : Unpacked>";
+        let res = parse_from_str(type_parser(), &mut ctx, unpacked_named).expect_ok(&ctx);
+        assert_eq!(&res.disp(&ctx).to_string(), unpacked_named);
 
         // Test parsing an opaque struct.
-        let test_string = "llvm.struct Unpacked <ExternStruct>";
+        let test_string = "llvm.struct <ExternStruct>";
         let res = parse_from_str(type_parser(), &mut ctx, test_string).expect_ok(&ctx);
         assert_eq!(&res.disp(&ctx).to_string(), test_string);
         {
             let res = res.deref(&ctx);
             let res = res.downcast_ref::<StructType>().unwrap();
             assert!(res.is_opaque() && res.is_named());
-            assert_eq!(res.layout(), StructLayout::Unpacked);
         }
 
         // Test parsing an unpacked unnamed struct.
-        let test_string = "llvm.struct Unpacked <{ builtin.integer i8 }>";
+        let test_string = "llvm.struct <{ builtin.integer i8 } : Unpacked>";
         let res = parse_from_str(type_parser(), &mut ctx, test_string).expect_ok(&ctx);
         assert_eq!(&res.disp(&ctx).to_string(), test_string);
         {
@@ -769,7 +746,7 @@ mod tests {
         }
 
         // Test parsing a packed unnamed struct.
-        let test_string = "llvm.struct Packed <{ builtin.integer i8 }>";
+        let test_string = "llvm.struct <{ builtin.integer i8 } : Packed>";
         let res = parse_from_str(type_parser(), &mut ctx, test_string).expect_ok(&ctx);
         assert_eq!(&res.disp(&ctx).to_string(), test_string);
         {
@@ -780,7 +757,7 @@ mod tests {
         }
 
         // Test parsing a packed named struct.
-        let test_string = "llvm.struct Packed <Packed { builtin.integer i8 }>";
+        let test_string = "llvm.struct <PackedS { builtin.integer i8 } : Packed>";
         let res = parse_from_str(type_parser(), &mut ctx, test_string).expect_ok(&ctx);
         assert_eq!(&res.disp(&ctx).to_string(), test_string);
         {
@@ -798,7 +775,7 @@ mod tests {
         let _ = parse_from_str(
             type_parser(),
             &mut ctx,
-            "llvm.struct Unpacked < My1 { builtin.integer i8 } >",
+            "llvm.struct < My1 { builtin.integer i8 } : Unpacked >",
         )
         .expect_ok(&ctx);
 
@@ -807,14 +784,14 @@ mod tests {
             parse_from_str(
                 type_parser(),
                 &mut ctx,
-                "llvm.struct Unpacked < My1 { builtin.integer i16 } >",
+                "llvm.struct < My1 { builtin.integer i16 } : Unpacked>",
             )
             .unwrap_err()
         );
 
         let expected_err_msg = expect![[r#"
             Compilation error: invalid input program.
-            Parse error at line: 1, column: 24
+            Parse error at line: 1, column: 15
             struct My1 already exists and is different
         "#]];
         expected_err_msg.assert_eq(&err_msg);

--- a/pliron-llvm/tests/compile_run.rs
+++ b/pliron-llvm/tests/compile_run.rs
@@ -328,7 +328,7 @@ fn test_insert_extract_value() {
             .to_str()
             .unwrap(),
         create_opt_pass_manager(),
-        103,
+        130,
     );
 }
 

--- a/pliron-llvm/tests/ir_expect.rs
+++ b/pliron-llvm/tests/ir_expect.rs
@@ -159,48 +159,87 @@ fn llvm_ir_select_without_fastmath_flags_omits_attr() -> Result<()> {
     Ok(())
 }
 
-/// Packed named and literal structs imported from LLVM IR must preserve their
-/// layout through pliron and back to LLVM IR.
+/// Combinations of `struct` types
 #[test]
-fn llvm_ir_packed_struct_roundtrip() -> Result<()> {
+fn llvm_ir_struct_combinations_roundtrip() -> Result<()> {
     init_env_logger_for_tests!();
     let input = r#"
-        %Packet = type <{ i8, i32 }>
+        %Packed = type <{ i8, i32 }>
+        %Unpacked = type { i8, i32 }
+        %Nested = type { %Packed, %Unpacked, i16 }
+        %List = type { i32, %List* }
+        %Opaque = type opaque
 
-        @named_packet = global %Packet zeroinitializer
-        @literal_packet = global <{ i16, i8 }> zeroinitializer
+        define void @use_structs(%Opaque* %op) {
+        entry:
+          %packed = alloca %Packed
+          %p0 = insertvalue %Packed undef, i8 1, 0
+          %p1 = insertvalue %Packed %p0, i32 2, 1
+          store %Packed %p1, %Packed* %packed
+
+          %unpacked = alloca %Unpacked
+          %u0 = insertvalue %Unpacked undef, i8 3, 0
+          %u1 = insertvalue %Unpacked %u0, i32 4, 1
+          store %Unpacked %u1, %Unpacked* %unpacked
+
+          %anonu = alloca { i8, i32 }
+          %au0 = insertvalue { i8, i32 } undef, i8 5, 0
+          %au1 = insertvalue { i8, i32 } %au0, i32 6, 1
+          store { i8, i32 } %au1, { i8, i32 }* %anonu
+
+          %anonp = alloca <{ i8, i32 }>
+          %ap0 = insertvalue <{ i8, i32 }> undef, i8 7, 0
+          %ap1 = insertvalue <{ i8, i32 }> %ap0, i32 8, 1
+          store <{ i8, i32 }> %ap1, <{ i8, i32 }>* %anonp
+
+          %nested = alloca %Nested
+          %n0 = insertvalue %Nested undef, %Packed %p1, 0
+          %n1 = insertvalue %Nested %n0, %Unpacked %u1, 1
+          %n2 = insertvalue %Nested %n1, i16 9, 2
+          store %Nested %n2, %Nested* %nested
+
+          %list = alloca %List
+          %l0 = insertvalue %List undef, i32 10, 0
+          %l1 = insertvalue %List %l0, %List* null, 1
+          store %List %l1, %List* %list
+
+          ret void
+        }
     "#;
 
     let llvm_ctx = LLVMContext::default();
     let ctx = &mut Context::new();
-    let module_op = common::parse_llvm_ir_verify(ctx, &llvm_ctx, input, "packed_structs")?;
-
-    let pliron_text = module_op.disp(ctx).to_string();
-    assert!(
-        pliron_text
-            .contains("llvm.struct Packed <Packet { builtin.integer i8, builtin.integer i32 }>"),
-        "named packed struct was not preserved in pliron IR:\n{pliron_text}"
-    );
-    assert!(
-        pliron_text.contains("llvm.struct Packed <{ builtin.integer i16, builtin.integer i8 }>"),
-        "literal packed struct was not preserved in pliron IR:\n{pliron_text}"
-    );
+    let module_op = common::parse_llvm_ir_verify(ctx, &llvm_ctx, input, "struct_combos")?;
 
     let out_llvm_ctx = LLVMContext::default();
     let out_mod = to_llvm_ir::convert_module(ctx, &out_llvm_ctx, module_op)?;
     let out = out_mod.to_string();
-    assert!(
-        out.contains("%Packet = type <{ i8, i32 }>"),
-        "named packed struct was not preserved in LLVM IR:\n{out}"
-    );
-    assert!(
-        out.contains("@named_packet = global %Packet zeroinitializer"),
-        "named packed global was not preserved in LLVM IR:\n{out}"
-    );
-    assert!(
-        out.contains("@literal_packet = global <{ i16, i8 }> zeroinitializer"),
-        "literal packed global was not preserved in LLVM IR:\n{out}"
-    );
+    expect![[r#"
+        ; ModuleID = 'struct_combos'
+        source_filename = "struct_combos"
 
+        %Packed = type <{ i8, i32 }>
+        %Unpacked = type { i8, i32 }
+        %Nested = type { %Packed, %Unpacked, i16 }
+        %List = type { i32, ptr }
+
+        define void @use_structs(ptr %0) {
+        entry_block2v1:
+          %packed_v2 = alloca %Packed, align 8
+          store %Packed <{ i8 1, i32 2 }>, ptr %packed_v2, align 1
+          %unpacked_v8 = alloca %Unpacked, align 8
+          store %Unpacked { i8 3, i32 4 }, ptr %unpacked_v8, align 4
+          %anonu_v14 = alloca { i8, i32 }, align 8
+          store { i8, i32 } { i8 5, i32 6 }, ptr %anonu_v14, align 4
+          %anonp_v20 = alloca <{ i8, i32 }>, align 8
+          store <{ i8, i32 }> <{ i8 7, i32 8 }>, ptr %anonp_v20, align 1
+          %nested_v26 = alloca %Nested, align 8
+          store %Nested { %Packed <{ i8 1, i32 2 }>, %Unpacked { i8 3, i32 4 }, i16 9 }, ptr %nested_v26, align 4
+          %list_v32 = alloca %List, align 8
+          store %List { i32 10, ptr null }, ptr %list_v32, align 8
+          ret void
+        }
+    "#]]
+    .assert_eq(&out);
     Ok(())
 }

--- a/pliron-llvm/tests/ir_expect.rs
+++ b/pliron-llvm/tests/ir_expect.rs
@@ -158,3 +158,49 @@ fn llvm_ir_select_without_fastmath_flags_omits_attr() -> Result<()> {
 
     Ok(())
 }
+
+/// Packed named and literal structs imported from LLVM IR must preserve their
+/// layout through pliron and back to LLVM IR.
+#[test]
+fn llvm_ir_packed_struct_roundtrip() -> Result<()> {
+    init_env_logger_for_tests!();
+    let input = r#"
+        %Packet = type <{ i8, i32 }>
+
+        @named_packet = global %Packet zeroinitializer
+        @literal_packet = global <{ i16, i8 }> zeroinitializer
+    "#;
+
+    let llvm_ctx = LLVMContext::default();
+    let ctx = &mut Context::new();
+    let module_op = common::parse_llvm_ir_verify(ctx, &llvm_ctx, input, "packed_structs")?;
+
+    let pliron_text = module_op.disp(ctx).to_string();
+    assert!(
+        pliron_text
+            .contains("llvm.struct Packed <Packet { builtin.integer i8, builtin.integer i32 }>"),
+        "named packed struct was not preserved in pliron IR:\n{pliron_text}"
+    );
+    assert!(
+        pliron_text.contains("llvm.struct Packed <{ builtin.integer i16, builtin.integer i8 }>"),
+        "literal packed struct was not preserved in pliron IR:\n{pliron_text}"
+    );
+
+    let out_llvm_ctx = LLVMContext::default();
+    let out_mod = to_llvm_ir::convert_module(ctx, &out_llvm_ctx, module_op)?;
+    let out = out_mod.to_string();
+    assert!(
+        out.contains("%Packet = type <{ i8, i32 }>"),
+        "named packed struct was not preserved in LLVM IR:\n{out}"
+    );
+    assert!(
+        out.contains("@named_packet = global %Packet zeroinitializer"),
+        "named packed global was not preserved in LLVM IR:\n{out}"
+    );
+    assert!(
+        out.contains("@literal_packet = global <{ i16, i8 }> zeroinitializer"),
+        "literal packed global was not preserved in LLVM IR:\n{out}"
+    );
+
+    Ok(())
+}

--- a/pliron-llvm/tests/resources/insert_extract_value.ll
+++ b/pliron-llvm/tests/resources/insert_extract_value.ll
@@ -1,6 +1,24 @@
 ; Define a struct type
 %MyStruct = type { i32, i64 }
 
+; A packed named struct.
+%Packed = type <{ i8, i32 }>
+
+; A struct nested inside another struct, mixing packed and unpacked layouts.
+%Nested = type { %MyStruct, %Packed, i16 }
+
+; A recursive struct type, self-referential through a pointer field.
+%List = type { i32, %List* }
+
+; A struct that is never given a body, used only behind a pointer.
+%Opaque = type opaque
+
+; Only touches the opaque struct via a pointer, to exercise the
+; never-defined named-struct type through argument passing.
+define i32 @use_opaque(%Opaque* %p) {
+  ret i32 7
+}
+
 ; Define a function to demonstrate insertvalue and extractvalue
 define i32 @main() {
 entry:
@@ -38,5 +56,56 @@ entry:
   ; Combine the results of the struct and array computations
   %result = add i32 %struct_computation, %final_computation
 
-  ret i32 %result
+  ; Packed named struct.
+  %packed = alloca %Packed
+  %packed0 = insertvalue %Packed undef, i8 1, 0
+  %packed1 = insertvalue %Packed %packed0, i32 2, 1
+  store %Packed %packed1, %Packed* %packed
+  %packed_loaded = load %Packed, %Packed* %packed
+  %packed_field = extractvalue %Packed %packed_loaded, 1
+  %result1 = add i32 %result, %packed_field
+
+  ; Anonymous unpacked struct.
+  %anonu = alloca { i8, i32 }
+  %anonu0 = insertvalue { i8, i32 } undef, i8 1, 0
+  %anonu1 = insertvalue { i8, i32 } %anonu0, i32 3, 1
+  store { i8, i32 } %anonu1, { i8, i32 }* %anonu
+  %anonu_loaded = load { i8, i32 }, { i8, i32 }* %anonu
+  %anonu_field = extractvalue { i8, i32 } %anonu_loaded, 1
+  %result2 = add i32 %result1, %anonu_field
+
+  ; Anonymous packed struct.
+  %anonp = alloca <{ i8, i32 }>
+  %anonp0 = insertvalue <{ i8, i32 }> undef, i8 1, 0
+  %anonp1 = insertvalue <{ i8, i32 }> %anonp0, i32 4, 1
+  store <{ i8, i32 }> %anonp1, <{ i8, i32 }>* %anonp
+  %anonp_loaded = load <{ i8, i32 }>, <{ i8, i32 }>* %anonp
+  %anonp_field = extractvalue <{ i8, i32 }> %anonp_loaded, 1
+  %result3 = add i32 %result2, %anonp_field
+
+  ; Struct nested inside another struct.
+  %nested = alloca %Nested
+  %nested0 = insertvalue %Nested undef, %MyStruct %struct_final, 0
+  %nested1 = insertvalue %Nested %nested0, %Packed %packed1, 1
+  %nested2 = insertvalue %Nested %nested1, i16 5, 2
+  store %Nested %nested2, %Nested* %nested
+  %nested_loaded = load %Nested, %Nested* %nested
+  %nested_field = extractvalue %Nested %nested_loaded, 2
+  %nested_field_ext = sext i16 %nested_field to i32
+  %result4 = add i32 %result3, %nested_field_ext
+
+  ; Recursive struct type (self-referential through a pointer field).
+  %list = alloca %List
+  %list0 = insertvalue %List undef, i32 6, 0
+  %list1 = insertvalue %List %list0, %List* null, 1
+  store %List %list1, %List* %list
+  %list_loaded = load %List, %List* %list
+  %list_field = extractvalue %List %list_loaded, 0
+  %result5 = add i32 %result4, %list_field
+
+  ; Opaque struct, used only via a pointer, passed to a function.
+  %opaque_call = call i32 @use_opaque(%Opaque* null)
+  %result6 = add i32 %result5, %opaque_call
+
+  ret i32 %result6
 }


### PR DESCRIPTION
## Description

`StructType` now tracks a `StructLayout`. `StructLayout` forms an additional part of  `StructType::get_named` and `StructType::get_unnamed`'s arguments. It is also a mandatory part of the printed syntax. Both of these changes make this PR a breaking change.

The new syntax looks like this:

```text
llvm.struct <{ ... } : Unpacked>
llvm.struct <{ ... } : Packed>
llvm.struct <Name { ... } : Packed>
```

The methods' argument `fields: Option<Vec<TypeHandle>>` is changed to `body: Option<(Vec<TypeHandle>, StructLayout)>`

## Checklist

* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
* [x] A human is involved in writing this PR description and will handle review interactions, per our [AI tool policy](../CONTRIBUTING.md).
* [x] I understand every part of this change (including any AI-generated code) and can explain the reasoning behind it.
* [x] Intrusive / large changes were discussed on Discord before this PR.
* [x] `pre-ci.sh` passes locally.
