### PR TITLE
[pliron-llvm]: Add ScalarOrVector{Opd,Res} interfaces for vector element ops

### DIFF
--- a/pliron-derive/Cargo.toml
+++ b/pliron-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pliron-derive"
-description = "LLVM Dialect for pliron"
+description = "Derive macros for pliron"
 version.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/pliron-llvm/src/op_interfaces.rs
+++ b/pliron-llvm/src/op_interfaces.rs
@@ -588,7 +588,7 @@ fn verify_impls_i_or_vec_of_impls_i<I: ?Sized + TypeInterfaceMarker + 'static>(
     Ok(())
 }
 
-/// An operand whose type is either `T or [`VectorType<T>`](VectorType).
+/// An operand whose type is either `T` or [`VectorType<T>`](VectorType).
 #[op_interface]
 pub trait ScalarOrVectorOpd<T: Type, const N: usize> {
     /// Get the type of operand N, or its element type if its [VectorType].

--- a/pliron-llvm/src/op_interfaces.rs
+++ b/pliron-llvm/src/op_interfaces.rs
@@ -3,17 +3,24 @@
 
 //! [Op] Interfaces defined in the LLVM dialect.
 
-use alloc::{string::String, vec};
+use alloc::{
+    string::{String, ToString},
+    vec,
+};
 
 use pliron::{
     builtin::{
         attributes::BoolAttr,
-        op_interfaces::{NOpdsInterface, OneOpdInterface, ResultNOfType, SymbolOpInterface},
+        op_interfaces::{
+            NOpdsInterface, OneOpdInterface, ResultNOfType, SymbolOpInterface,
+            verify_get_operand_n, verify_get_result_n,
+        },
         type_interfaces::FloatTypeInterface,
     },
     derive::op_interface,
     dict_key,
-    r#type::type_cast,
+    printable::Printable,
+    r#type::{Type, TypeInterfaceMarker, TypedHandle, type_impls},
     utils::const_bound_n::I,
 };
 use thiserror::Error;
@@ -24,7 +31,7 @@ use pliron::{
         types::{IntegerType, Signedness},
     },
     context::Context,
-    location::Located,
+    location::{Located, Location},
     op::{Op, op_cast},
     operation::Operation,
     result::Result,
@@ -35,7 +42,7 @@ use pliron::{
 
 use crate::{
     attributes::{AlignmentAttr, FastmathFlagsAttr},
-    types::VectorType,
+    types::{VectorType, VectorTypeKind},
 };
 
 use super::{attributes::IntegerOverflowFlagsAttr, types::PointerType};
@@ -89,24 +96,15 @@ pub struct IntBinArithOpErr;
 
 /// Integer binary arithmetic [Op]
 #[op_interface]
-pub trait IntBinArithOp: BinArithOp {
+pub trait IntBinArithOp: BinArithOp + ScalarOrVectorOpd<IntegerType, 0> {
     fn verify(op: &dyn Op, ctx: &Context) -> Result<()>
     where
         Self: Sized,
     {
-        let mut ty = op_cast::<dyn BinArithOp>(op)
-            .expect("Op must impl BinArithOp")
-            .operand_type_i(ctx, I::<0>.into());
-
-        if let Some(vec_ty) = ty.deref(ctx).downcast_ref::<VectorType>() {
-            ty = vec_ty.elem_type();
-        }
-
-        let ty = ty.deref(ctx);
-        let Some(int_ty) = ty.downcast_ref::<IntegerType>() else {
-            return verify_err!(op.loc(ctx), IntBinArithOpErr);
-        };
-
+        let int_ty = op_cast::<dyn ScalarOrVectorOpd<IntegerType, 0>>(op)
+            .expect("Op must impl ScalarOrVectorOpd<IntegerType, 0>")
+            .scalar_or_vector_elem_ty(ctx);
+        let int_ty = int_ty.deref(ctx);
         if int_ty.signedness() != Signedness::Signless {
             return verify_err!(op.loc(ctx), IntBinArithOpErr);
         }
@@ -184,29 +182,13 @@ pub trait IntBinArithOpWithOverflowFlag: IntBinArithOp {
     }
 }
 
-#[derive(Error, Debug)]
-#[error("Floating point arithmetic Op can only have signless floating point result/operand type")]
-pub struct FloatBinArithOpErr;
-
 /// Floating point binary arithmetic [Op]
 #[op_interface]
-pub trait FloatBinArithOp: BinArithOp {
-    fn verify(op: &dyn Op, ctx: &Context) -> Result<()>
+pub trait FloatBinArithOp: BinArithOp + ScalarOrVectorOpdImpls<dyn FloatTypeInterface, 0> {
+    fn verify(_op: &dyn Op, _ctx: &Context) -> Result<()>
     where
         Self: Sized,
     {
-        let mut ty = op_cast::<dyn BinArithOp>(op)
-            .expect("Op must impl BinArithOp")
-            .operand_type_i(ctx, I::<0>.into());
-
-        if let Some(vec_ty) = ty.deref(ctx).downcast_ref::<VectorType>() {
-            ty = vec_ty.elem_type();
-        }
-
-        let ty = ty.deref(ctx);
-        if type_cast::<dyn FloatTypeInterface>(&*ty).is_none() {
-            return verify_err!(op.loc(ctx), FloatBinArithOpErr);
-        }
         Ok(())
     }
 }
@@ -500,5 +482,204 @@ pub trait AlignableOpInterface {
         Self: Sized,
     {
         Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ScalarOrVectorErr {
+    #[error("{0} is not {1} or a vector of it")]
+    NotTOrVectorOfT(String, String),
+    #[error("{0} or its vector element type does not implement interface")]
+    TyOrElemNotImplsI(String),
+}
+
+/// Get the vector shape of `ty`, or `None` if it is not a [VectorType].
+fn vector_shape_of(ty: TypeHandle, ctx: &Context) -> Option<(u32, VectorTypeKind)> {
+    ty.deref(ctx)
+        .downcast_ref::<VectorType>()
+        .map(|vec_ty| (vec_ty.num_elements(), vec_ty.kind()))
+}
+
+/// Get `ty`, or its element type if it is a [VectorType], typed as `T`.
+///
+/// Only valid to call once `verify_t_or_vec_of_t::<T>` has passed for `ty`.
+fn elem_ty_of<T: Type>(ty: TypeHandle, ctx: &Context) -> TypedHandle<T> {
+    if let Ok(typed_handle) = TypedHandle::from_handle(ty, ctx) {
+        return typed_handle;
+    }
+    let ty_ref = &*ty.deref(ctx);
+    let elem_ty = ty_ref
+        .downcast_ref::<VectorType>()
+        .expect("verify() guarantees type is T or a vector of T")
+        .elem_type();
+    TypedHandle::from_handle(elem_ty, ctx).expect("verify() guarantees element type is T")
+}
+
+/// Verify that `ty` is `T`, or a [VectorType] of `T`.
+fn verify_t_or_vec_of_t<T: Type>(loc: Location, ty: &dyn Type, ctx: &Context) -> Result<()> {
+    if ty.is::<T>() {
+        // ty is equal to `T`, we're good.
+        return Ok(());
+    }
+    // See if `ty` is a vector of `T`.
+    let Some(vec_ty) = ty.downcast_ref::<VectorType>() else {
+        return verify_err!(
+            loc,
+            ScalarOrVectorErr::NotTOrVectorOfT(
+                ty.get_type_id().disp(ctx).to_string(),
+                T::get_type_id_static().disp(ctx).to_string()
+            )
+        );
+    };
+    let elem_ty = &*vec_ty.elem_type().deref(ctx);
+    if !elem_ty.is::<T>() {
+        return verify_err!(
+            loc,
+            ScalarOrVectorErr::NotTOrVectorOfT(
+                ty.get_type_id().disp(ctx).to_string(),
+                T::get_type_id_static().disp(ctx).to_string()
+            )
+        );
+    }
+    Ok(())
+}
+
+/// Get `ty`, or its element type if it is a [VectorType], whichever implements `I`.
+///
+/// Only valid to call once `verify_impls_i_or_vec_of_impls_i::<I>` has passed for `ty`.
+fn elem_ty_of_impls<I: ?Sized + TypeInterfaceMarker + 'static>(
+    ty: TypeHandle,
+    ctx: &Context,
+) -> TypeHandle {
+    let ty_ref = &*ty.deref(ctx);
+    if type_impls::<I>(ty_ref) {
+        return ty;
+    }
+    ty_ref
+        .downcast_ref::<VectorType>()
+        .expect("verify() guarantees type impls I or is a vector whose elem impls I")
+        .elem_type()
+}
+
+/// Verify that `ty` implements `I`, or is a [VectorType] whose element type implements `I`.
+fn verify_impls_i_or_vec_of_impls_i<I: ?Sized + TypeInterfaceMarker + 'static>(
+    loc: Location,
+    ty: &dyn Type,
+    ctx: &Context,
+) -> Result<()> {
+    if type_impls::<I>(ty) {
+        // ty implements `I`, we're good.
+        return Ok(());
+    }
+    // See if `ty` is a vector whose element type implements `I`.
+    let Some(vec_ty) = ty.downcast_ref::<VectorType>() else {
+        return verify_err!(
+            loc,
+            ScalarOrVectorErr::TyOrElemNotImplsI(ty.get_type_id().disp(ctx).to_string())
+        );
+    };
+    let elem_ty = &*vec_ty.elem_type().deref(ctx);
+    if !type_impls::<I>(elem_ty) {
+        return verify_err!(
+            loc,
+            ScalarOrVectorErr::TyOrElemNotImplsI(ty.get_type_id().disp(ctx).to_string())
+        );
+    }
+    Ok(())
+}
+
+/// An operand whose type is either `T or [`VectorType<T>`](VectorType).
+#[op_interface]
+pub trait ScalarOrVectorOpd<T: Type, const N: usize> {
+    /// Get the type of operand N, or its element type if its [VectorType].
+    fn scalar_or_vector_elem_ty(&self, ctx: &Context) -> TypedHandle<T> {
+        let op = &*self.get_operation().deref(ctx);
+        elem_ty_of(op.get_operand(N).get_type(ctx), ctx)
+    }
+
+    /// Get the vector shape of operand N, or `None` if it is not a [VectorType].
+    fn vector_shape(&self, ctx: &Context) -> Option<(u32, VectorTypeKind)> {
+        let op = &*self.get_operation().deref(ctx);
+        vector_shape_of(op.get_operand(N).get_type(ctx), ctx)
+    }
+
+    fn verify(op: &dyn Op, ctx: &Context) -> Result<()>
+    where
+        Self: Sized,
+    {
+        let opd = verify_get_operand_n::<N>(op.get_operation(), ctx)?;
+        verify_t_or_vec_of_t::<T>(op.loc(ctx), &*opd.get_type(ctx).deref(ctx), ctx)
+    }
+}
+
+/// An operand whose type either impls `I` or is [`VectorType<T: I>`](VectorType).
+#[op_interface]
+pub trait ScalarOrVectorOpdImpls<I: ?Sized + TypeInterfaceMarker + 'static, const N: usize> {
+    /// Get the type of operand N, or its element type if its [VectorType].
+    fn scalar_or_vector_elem_ty(&self, ctx: &Context) -> TypeHandle {
+        let op = &*self.get_operation().deref(ctx);
+        elem_ty_of_impls::<I>(op.get_operand(N).get_type(ctx), ctx)
+    }
+
+    /// Get the vector shape of operand N, or `None` if it is not a [VectorType].
+    fn vector_shape(&self, ctx: &Context) -> Option<(u32, VectorTypeKind)> {
+        let op = &*self.get_operation().deref(ctx);
+        vector_shape_of(op.get_operand(N).get_type(ctx), ctx)
+    }
+
+    fn verify(op: &dyn Op, ctx: &Context) -> Result<()>
+    where
+        Self: Sized,
+    {
+        let opd = verify_get_operand_n::<N>(op.get_operation(), ctx)?;
+        verify_impls_i_or_vec_of_impls_i::<I>(op.loc(ctx), &*opd.get_type(ctx).deref(ctx), ctx)
+    }
+}
+
+/// A result whose type is either `T` or [`VectorType<T>`](VectorType).
+#[op_interface]
+pub trait ScalarOrVectorRes<T: Type, const N: usize> {
+    /// Get the type of result N, or its element type if its [VectorType].
+    fn scalar_or_vector_elem_ty(&self, ctx: &Context) -> TypedHandle<T> {
+        let op = &*self.get_operation().deref(ctx);
+        elem_ty_of(op.get_result(N).get_type(ctx), ctx)
+    }
+
+    /// Get the vector shape of result N, or `None` if it is not a [VectorType].
+    fn vector_shape(&self, ctx: &Context) -> Option<(u32, VectorTypeKind)> {
+        let op = &*self.get_operation().deref(ctx);
+        vector_shape_of(op.get_result(N).get_type(ctx), ctx)
+    }
+
+    fn verify(op: &dyn Op, ctx: &Context) -> Result<()>
+    where
+        Self: Sized,
+    {
+        let res = verify_get_result_n::<N>(op.get_operation(), ctx)?;
+        verify_t_or_vec_of_t::<T>(op.loc(ctx), &*res.get_type(ctx).deref(ctx), ctx)
+    }
+}
+
+/// A result whose type either impls `I` or is [`VectorType<T: I>`](VectorType).
+#[op_interface]
+pub trait ScalarOrVectorResImpls<I: ?Sized + TypeInterfaceMarker + 'static, const N: usize> {
+    /// Get the type of result N, or its element type if its [VectorType].
+    fn scalar_or_vector_elem_ty(&self, ctx: &Context) -> TypeHandle {
+        let op = &*self.get_operation().deref(ctx);
+        elem_ty_of_impls::<I>(op.get_result(N).get_type(ctx), ctx)
+    }
+
+    /// Get the vector shape of result N, or `None` if it is not a [VectorType].
+    fn vector_shape(&self, ctx: &Context) -> Option<(u32, VectorTypeKind)> {
+        let op = &*self.get_operation().deref(ctx);
+        vector_shape_of(op.get_result(N).get_type(ctx), ctx)
+    }
+
+    fn verify(op: &dyn Op, ctx: &Context) -> Result<()>
+    where
+        Self: Sized,
+    {
+        let res = verify_get_result_n::<N>(op.get_operation(), ctx)?;
+        verify_impls_i_or_vec_of_impls_i::<I>(op.loc(ctx), &*res.get_type(ctx).deref(ctx), ctx)
     }
 }

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -45,14 +45,14 @@ use pliron::{
     },
     linked_list::ContainsLinkedList,
     location::{Located, Location},
-    op::{Op, OpObj},
+    op::{Op, OpObj, op_cast},
     operation::Operation,
     parsable::{IntoParseResult, Parsable, ParseResult, StateStream},
     printable::{self, Printable, indented_nl},
     region::Region,
     result::{Error, ErrorKind, Result},
     symbol_table::SymbolTableCollection,
-    r#type::{TypeHandle, TypedHandle, type_cast, type_impls},
+    r#type::{TypeHandle, TypedHandle, type_cast},
     utils::{apint::APInt, const_bound_n::I, vec_exns::VecExtns},
     value::Value,
     verify_err, verify_error,
@@ -68,6 +68,7 @@ use crate::{
         AlignableOpInterface, BinArithOp, CastOpInterface, CastOpWithNNegInterface, FastMathFlags,
         FloatBinArithOp, FloatBinArithOpWithFastMathFlags, IntBinArithOp,
         IntBinArithOpWithOverflowFlag, IsDeclaration, LlvmSymbolName, NNegFlag, PointerTypeResult,
+        ScalarOrVectorOpd, ScalarOrVectorOpdImpls, ScalarOrVectorRes, ScalarOrVectorResImpls,
     },
     ops::{
         func_op_attr_names::ATTR_KEY_LLVM_FUNC_TYPE,
@@ -205,7 +206,8 @@ macro_rules! new_int_bin_op_with_format {
             format = $format,
             interfaces = [
                 OneResultInterface, SameOperandsType, SameResultsType,
-                SameOperandsAndResultType, BinArithOp, IntBinArithOp, NOpdsInterface<2>
+                SameOperandsAndResultType, BinArithOp, IntBinArithOp,
+                ScalarOrVectorOpd<IntegerType, 0>, NOpdsInterface<2>
             ],
             verifier = "succ"
         )]
@@ -351,7 +353,12 @@ pub enum ICmpOpVerifyErr {
 #[pliron_op(
     name = "llvm.icmp",
     format = "$0 ` <` attr($icmp_predicate, $ICmpPredicateAttr) `> ` $1 ` : ` type($0)",
-    interfaces = [SameOperandsType, OneResultInterface, NOpdsInterface<2>],
+    interfaces = [
+        SameOperandsType,
+        OneResultInterface,
+        NOpdsInterface<2>,
+        ScalarOrVectorRes<IntegerType, 0>,
+    ],
     attributes = (icmp_predicate: ICmpPredicateAttr)
 )]
 pub struct ICmpOp;
@@ -403,28 +410,20 @@ impl Verify for ICmpOp {
             verify_err!(loc.clone(), ICmpOpVerifyErr::PredAttrErr)?
         }
 
-        let mut res_ty = self.result_type(ctx);
-        let mut vec_num_elements = None;
-        if let Some(vec_ty) = res_ty.deref(ctx).downcast_ref::<VectorType>() {
-            res_ty = vec_ty.elem_type();
-            vec_num_elements = Some(vec_ty.num_elements());
-        }
-        let res_ty = res_ty.deref(ctx);
-        let Some(res_ty) = res_ty.downcast_ref::<IntegerType>() else {
-            return verify_err!(loc, ICmpOpVerifyErr::ResultNotBool);
-        };
-        if res_ty.width() != 1 {
+        let res_ty = self.scalar_or_vector_elem_ty(ctx);
+        if res_ty.deref(ctx).width() != 1 {
             return verify_err!(loc, ICmpOpVerifyErr::ResultNotBool);
         }
+        let res_shape = self.vector_shape(ctx);
 
         let mut opd_ty = self.operand_type_i(ctx, I::<0>.into());
-        if let Some(vec_ty) = opd_ty.deref(ctx).downcast_ref::<VectorType>() {
-            opd_ty = vec_ty.elem_type();
-            // Ensure that the number of elements matches the result type's number of elements.
-            if vec_num_elements.is_none_or(|num_elements| vec_ty.num_elements() != num_elements) {
-                return verify_err!(loc, ICmpOpVerifyErr::MismatchedVectorNumElements);
-            }
-        } else if vec_num_elements.is_some() {
+        let opd_shape = opd_ty
+            .deref(ctx)
+            .downcast_ref::<VectorType>()
+            .inspect(|vec_ty| opd_ty = vec_ty.elem_type())
+            .map(|vec_ty| (vec_ty.num_elements(), vec_ty.kind()));
+
+        if opd_shape != res_shape {
             return verify_err!(loc, ICmpOpVerifyErr::MismatchedVectorNumElements);
         }
         let opd_ty = opd_ty.deref(ctx);
@@ -3025,66 +3024,60 @@ impl SymbolUserOpInterface for BlockAddressOp {
 
 #[derive(Error, Debug)]
 enum IntCastVerifyErr {
-    #[error("Result must be an integer")]
-    ResultTypeErr,
-    #[error("Operand must be an integer")]
-    OperandTypeErr,
     #[error("Result type must be larger than operand type")]
-    ResultTypeSmallerThanOperand,
+    SmallerThanOperand,
     #[error("Result type must be smaller than operand type")]
-    ResultTypeLargerThanOperand,
+    LargerThanOperand,
     #[error("Result type must be equal to operand type")]
-    ResultTypeEqualToOperand,
+    NotEqualToOperand,
+    #[error("Operand and result must both be scalars or vectors with matching shape")]
+    MismatchedVectorShape,
 }
 
 /// Ensure that the integer cast operation is valid.
 /// This checks that the result type is an integer and that the operand type is also an integer.
 /// It also checks that the result type is larger or smaller than the operand type (`cmp` operand).
-fn integer_cast_verify(op: &Operation, ctx: &Context, cmp: ICmpPredicateAttr) -> Result<()> {
-    use pliron::r#type::Typed;
+fn integer_cast_verify(op: &dyn Op, ctx: &Context, cmp: ICmpPredicateAttr) -> Result<()> {
+    let loc = op.loc(ctx);
 
-    let loc = op.loc();
-    let mut res_ty = op.get_type(0).deref(ctx);
-    let mut opd_ty = op.get_operand(0).get_type(ctx).deref(ctx);
+    let opd_iface = op_cast::<dyn ScalarOrVectorOpd<IntegerType, 0>>(op)
+        .expect("Op must impl ScalarOrVectorOpd<IntegerType, 0>");
+    let res_iface = op_cast::<dyn ScalarOrVectorRes<IntegerType, 0>>(op)
+        .expect("Op must impl ScalarOrVectorRes<IntegerType, 0>");
 
-    if let Some(vec_res_ty) = res_ty.downcast_ref::<VectorType>() {
-        res_ty = vec_res_ty.elem_type().deref(ctx);
-    }
-    if let Some(vec_opd_ty) = opd_ty.downcast_ref::<VectorType>() {
-        opd_ty = vec_opd_ty.elem_type().deref(ctx);
+    if opd_iface.vector_shape(ctx) != res_iface.vector_shape(ctx) {
+        return verify_err!(loc, IntCastVerifyErr::MismatchedVectorShape);
     }
 
-    let Some(res_ty) = res_ty.downcast_ref::<IntegerType>() else {
-        return verify_err!(loc, IntCastVerifyErr::ResultTypeErr);
-    };
-    let Some(opd_ty) = opd_ty.downcast_ref::<IntegerType>() else {
-        return verify_err!(loc, IntCastVerifyErr::OperandTypeErr);
-    };
+    let opd_ty = opd_iface.scalar_or_vector_elem_ty(ctx);
+    let opd_ty = opd_ty.deref(ctx);
+    let res_ty = res_iface.scalar_or_vector_elem_ty(ctx);
+    let res_ty = res_ty.deref(ctx);
 
     match cmp {
         ICmpPredicateAttr::SLT | ICmpPredicateAttr::ULT => {
             if res_ty.width() >= opd_ty.width() {
-                return verify_err!(loc, IntCastVerifyErr::ResultTypeLargerThanOperand);
+                return verify_err!(loc, IntCastVerifyErr::LargerThanOperand);
             }
         }
         ICmpPredicateAttr::SGT | ICmpPredicateAttr::UGT => {
             if res_ty.width() <= opd_ty.width() {
-                return verify_err!(loc, IntCastVerifyErr::ResultTypeSmallerThanOperand);
+                return verify_err!(loc, IntCastVerifyErr::SmallerThanOperand);
             }
         }
         ICmpPredicateAttr::SLE | ICmpPredicateAttr::ULE => {
             if res_ty.width() > opd_ty.width() {
-                return verify_err!(loc, IntCastVerifyErr::ResultTypeLargerThanOperand);
+                return verify_err!(loc, IntCastVerifyErr::LargerThanOperand);
             }
         }
         ICmpPredicateAttr::SGE | ICmpPredicateAttr::UGE => {
             if res_ty.width() < opd_ty.width() {
-                return verify_err!(loc, IntCastVerifyErr::ResultTypeSmallerThanOperand);
+                return verify_err!(loc, IntCastVerifyErr::SmallerThanOperand);
             }
         }
         ICmpPredicateAttr::EQ | ICmpPredicateAttr::NE => {
             if res_ty.width() != opd_ty.width() {
-                return verify_err!(loc, IntCastVerifyErr::ResultTypeEqualToOperand);
+                return verify_err!(loc, IntCastVerifyErr::NotEqualToOperand);
             }
         }
     }
@@ -3103,16 +3096,18 @@ fn integer_cast_verify(op: &Operation, ctx: &Context, cmp: ICmpPredicateAttr) ->
 #[pliron_op(
     name = "llvm.sext",
     format = "$0 ` to ` type($0)",
-    interfaces = [CastOpInterface, OneResultInterface, OneOpdInterface]
+    interfaces = [
+        CastOpInterface,
+        OneResultInterface,
+        OneOpdInterface,
+        ScalarOrVectorOpd<IntegerType, 0>,
+        ScalarOrVectorRes<IntegerType, 0>,
+    ]
 )]
 pub struct SExtOp;
 impl Verify for SExtOp {
     fn verify(&self, ctx: &Context) -> Result<()> {
-        integer_cast_verify(
-            &self.get_operation().deref(ctx),
-            ctx,
-            ICmpPredicateAttr::SGT,
-        )
+        integer_cast_verify(self, ctx, ICmpPredicateAttr::SGT)
     }
 }
 
@@ -3134,17 +3129,15 @@ impl Verify for SExtOp {
         OneOpdInterface,
         NNegFlag,
         CastOpWithNNegInterface,
+        ScalarOrVectorOpd<IntegerType, 0>,
+        ScalarOrVectorRes<IntegerType, 0>,
     ]
 )]
 pub struct ZExtOp;
 
 impl Verify for ZExtOp {
     fn verify(&self, ctx: &Context) -> Result<()> {
-        integer_cast_verify(
-            &self.get_operation().deref(ctx),
-            ctx,
-            ICmpPredicateAttr::UGT,
-        )
+        integer_cast_verify(self, ctx, ICmpPredicateAttr::UGT)
     }
 }
 
@@ -3162,28 +3155,40 @@ impl Verify for ZExtOp {
 #[pliron_op(
     name = "llvm.fpext",
     format = "attr($llvm_fast_math_flags, $FastmathFlagsAttr) ` ` $0 ` to ` type($0)",
-    interfaces = [CastOpInterface, OneResultInterface, OneOpdInterface, FastMathFlags]
+    interfaces = [
+        CastOpInterface,
+        OneResultInterface,
+        OneOpdInterface,
+        FastMathFlags,
+        ScalarOrVectorOpdImpls<dyn FloatTypeInterface, 0>,
+        ScalarOrVectorResImpls<dyn FloatTypeInterface, 0>,
+    ]
 )]
 pub struct FPExtOp;
 
 impl Verify for FPExtOp {
     fn verify(&self, ctx: &Context) -> Result<()> {
-        // Check operand type to be a float
-        let mut opd_ty = self.operand_type(ctx).deref(ctx);
-        if let Some(vec_ty) = opd_ty.downcast_ref::<VectorType>() {
-            opd_ty = vec_ty.elem_type().deref(ctx);
-        }
-        let Some(opd_float_ty) = type_cast::<dyn FloatTypeInterface>(&*opd_ty) else {
-            return verify_err!(self.loc(ctx), FloatCastVerifyErr::OperandTypeErr);
-        };
+        let opd_ty = ScalarOrVectorOpdImpls::<dyn FloatTypeInterface, 0>::scalar_or_vector_elem_ty(
+            self, ctx,
+        );
+        let opd_ty = opd_ty.deref(ctx);
+        let opd_float_ty = type_cast::<dyn FloatTypeInterface>(&*opd_ty)
+            .expect("ScalarOrVectorOpdImpls<dyn FloatTypeInterface, 0> guarantees this");
 
-        let mut res_ty = self.result_type(ctx).deref(ctx);
-        if let Some(vec_ty) = res_ty.downcast_ref::<VectorType>() {
-            res_ty = vec_ty.elem_type().deref(ctx);
+        let res_ty = ScalarOrVectorResImpls::<dyn FloatTypeInterface, 0>::scalar_or_vector_elem_ty(
+            self, ctx,
+        );
+        let res_ty = res_ty.deref(ctx);
+        let res_float_ty = type_cast::<dyn FloatTypeInterface>(&*res_ty)
+            .expect("ScalarOrVectorResImpls<dyn FloatTypeInterface, 0> guarantees this");
+
+        let opd_shape =
+            ScalarOrVectorOpdImpls::<dyn FloatTypeInterface, 0>::vector_shape(self, ctx);
+        let res_shape =
+            ScalarOrVectorResImpls::<dyn FloatTypeInterface, 0>::vector_shape(self, ctx);
+        if opd_shape != res_shape {
+            return verify_err!(self.loc(ctx), FloatCastVerifyErr::MismatchedVectorShape);
         }
-        let Some(res_float_ty) = type_cast::<dyn FloatTypeInterface>(&*res_ty) else {
-            return verify_err!(self.loc(ctx), FloatCastVerifyErr::ResultTypeErr);
-        };
 
         let opd_size = opd_float_ty.get_semantics().bits;
         let res_size = res_float_ty.get_semantics().bits;
@@ -3223,17 +3228,19 @@ pub enum FloatCastVerifyErr {
 #[pliron_op(
     name = "llvm.trunc",
     format = "$0 ` to ` type($0)",
-    interfaces = [CastOpInterface, OneResultInterface, OneOpdInterface]
+    interfaces = [
+        CastOpInterface,
+        OneResultInterface,
+        OneOpdInterface,
+        ScalarOrVectorOpd<IntegerType, 0>,
+        ScalarOrVectorRes<IntegerType, 0>,
+    ]
 )]
 pub struct TruncOp;
 
 impl Verify for TruncOp {
     fn verify(&self, ctx: &Context) -> Result<()> {
-        integer_cast_verify(
-            &self.get_operation().deref(ctx),
-            ctx,
-            ICmpPredicateAttr::ULT,
-        )
+        integer_cast_verify(self, ctx, ICmpPredicateAttr::ULT)
     }
 }
 
@@ -3249,28 +3256,40 @@ impl Verify for TruncOp {
 #[pliron_op(
     name = "llvm.fptrunc",
     format = "attr($llvm_fast_math_flags, $FastmathFlagsAttr) ` ` $0 ` to ` type($0)",
-    interfaces = [CastOpInterface, OneResultInterface, OneOpdInterface, FastMathFlags]
+    interfaces = [
+        CastOpInterface,
+        OneResultInterface,
+        OneOpdInterface,
+        FastMathFlags,
+        ScalarOrVectorOpdImpls<dyn FloatTypeInterface, 0>,
+        ScalarOrVectorResImpls<dyn FloatTypeInterface, 0>,
+    ]
 )]
 pub struct FPTruncOp;
 
 impl Verify for FPTruncOp {
     fn verify(&self, ctx: &Context) -> Result<()> {
-        // Check operand type to be a float
-        let mut opd_ty = self.operand_type(ctx).deref(ctx);
-        if let Some(vec_ty) = opd_ty.downcast_ref::<VectorType>() {
-            opd_ty = vec_ty.elem_type().deref(ctx);
-        }
-        let Some(opd_float_ty) = type_cast::<dyn FloatTypeInterface>(&*opd_ty) else {
-            return verify_err!(self.loc(ctx), FloatCastVerifyErr::OperandTypeErr);
-        };
+        let opd_ty = ScalarOrVectorOpdImpls::<dyn FloatTypeInterface, 0>::scalar_or_vector_elem_ty(
+            self, ctx,
+        );
+        let opd_ty = opd_ty.deref(ctx);
+        let opd_float_ty = type_cast::<dyn FloatTypeInterface>(&*opd_ty)
+            .expect("ScalarOrVectorOpdImpls<dyn FloatTypeInterface, 0> guarantees this");
 
-        let mut res_ty = self.result_type(ctx).deref(ctx);
-        if let Some(vec_ty) = res_ty.downcast_ref::<VectorType>() {
-            res_ty = vec_ty.elem_type().deref(ctx);
+        let res_ty = ScalarOrVectorResImpls::<dyn FloatTypeInterface, 0>::scalar_or_vector_elem_ty(
+            self, ctx,
+        );
+        let res_ty = res_ty.deref(ctx);
+        let res_float_ty = type_cast::<dyn FloatTypeInterface>(&*res_ty)
+            .expect("ScalarOrVectorResImpls<dyn FloatTypeInterface, 0> guarantees this");
+
+        let opd_shape =
+            ScalarOrVectorOpdImpls::<dyn FloatTypeInterface, 0>::vector_shape(self, ctx);
+        let res_shape =
+            ScalarOrVectorResImpls::<dyn FloatTypeInterface, 0>::vector_shape(self, ctx);
+        if opd_shape != res_shape {
+            return verify_err!(self.loc(ctx), FloatCastVerifyErr::MismatchedVectorShape);
         }
-        let Some(res_float_ty) = type_cast::<dyn FloatTypeInterface>(&*res_ty) else {
-            return verify_err!(self.loc(ctx), FloatCastVerifyErr::ResultTypeErr);
-        };
 
         let opd_size = opd_float_ty.get_semantics().bits;
         let res_size = res_float_ty.get_semantics().bits;
@@ -3282,33 +3301,6 @@ impl Verify for FPTruncOp {
         }
         Ok(())
     }
-}
-
-fn cast_element_types(
-    opd_ty: TypeHandle,
-    res_ty: TypeHandle,
-    ctx: &Context,
-    loc: Location,
-) -> Result<(TypeHandle, TypeHandle)> {
-    let mut opd_elem_ty = opd_ty;
-    let mut res_elem_ty = res_ty;
-    let mut opd_vec_shape = None;
-    let mut res_vec_shape = None;
-
-    if let Some(vec_ty) = opd_ty.deref(ctx).downcast_ref::<VectorType>() {
-        opd_elem_ty = vec_ty.elem_type();
-        opd_vec_shape = Some((vec_ty.num_elements(), vec_ty.kind()));
-    }
-    if let Some(vec_ty) = res_ty.deref(ctx).downcast_ref::<VectorType>() {
-        res_elem_ty = vec_ty.elem_type();
-        res_vec_shape = Some((vec_ty.num_elements(), vec_ty.kind()));
-    }
-
-    if opd_vec_shape != res_vec_shape {
-        return verify_err!(loc, FloatCastVerifyErr::MismatchedVectorShape);
-    }
-
-    Ok((opd_elem_ty, res_elem_ty))
 }
 
 /// Equivalent to LLVM's FPToSI opcode.
@@ -3325,29 +3317,27 @@ fn cast_element_types(
 #[pliron_op(
     name = "llvm.fptosi",
     format = "$0 ` to ` type($0)",
-    interfaces = [CastOpInterface, OneResultInterface, OneOpdInterface]
+    interfaces = [
+        CastOpInterface,
+        OneResultInterface,
+        OneOpdInterface,
+        ScalarOrVectorOpdImpls<dyn FloatTypeInterface, 0>,
+        ScalarOrVectorRes<IntegerType, 0>,
+    ]
 )]
 pub struct FPToSIOp;
 
 impl Verify for FPToSIOp {
     fn verify(&self, ctx: &Context) -> Result<()> {
-        // Check that the operand is a float and the result is an integer
-        let (opd_ty, res_ty) = cast_element_types(
-            OneOpdInterface::operand_type(self, ctx),
-            OneResultInterface::result_type(self, ctx),
-            ctx,
-            self.loc(ctx),
-        )?;
-        let opd_ty = opd_ty.deref(ctx);
-        if !type_impls::<dyn FloatTypeInterface>(&*opd_ty) {
-            return verify_err!(self.loc(ctx), FloatCastVerifyErr::OperandTypeErr);
-        };
-        let res_ty = res_ty.deref(ctx);
-        let Some(res_int_ty) = res_ty.downcast_ref::<IntegerType>() else {
+        let res_int_ty = ScalarOrVectorRes::<IntegerType, 0>::scalar_or_vector_elem_ty(self, ctx);
+        if !res_int_ty.deref(ctx).is_signless() {
             return verify_err!(self.loc(ctx), FloatCastVerifyErr::ResultTypeErr);
-        };
-        if !res_int_ty.is_signless() {
-            return verify_err!(self.loc(ctx), FloatCastVerifyErr::ResultTypeErr);
+        }
+        let opd_shape =
+            ScalarOrVectorOpdImpls::<dyn FloatTypeInterface, 0>::vector_shape(self, ctx);
+        let res_shape = ScalarOrVectorRes::<IntegerType, 0>::vector_shape(self, ctx);
+        if opd_shape != res_shape {
+            return verify_err!(self.loc(ctx), FloatCastVerifyErr::MismatchedVectorShape);
         }
         Ok(())
     }
@@ -3367,29 +3357,27 @@ impl Verify for FPToSIOp {
 #[pliron_op(
     name = "llvm.fptoui",
     format = "$0 ` to ` type($0)",
-    interfaces = [CastOpInterface, OneResultInterface, OneOpdInterface]
+    interfaces = [
+        CastOpInterface,
+        OneResultInterface,
+        OneOpdInterface,
+        ScalarOrVectorOpdImpls<dyn FloatTypeInterface, 0>,
+        ScalarOrVectorRes<IntegerType, 0>,
+    ]
 )]
 pub struct FPToUIOp;
 
 impl Verify for FPToUIOp {
     fn verify(&self, ctx: &Context) -> Result<()> {
-        // Check that the operand is a float and the result is an integer
-        let (opd_ty, res_ty) = cast_element_types(
-            OneOpdInterface::operand_type(self, ctx),
-            OneResultInterface::result_type(self, ctx),
-            ctx,
-            self.loc(ctx),
-        )?;
-        let opd_ty = opd_ty.deref(ctx);
-        if !type_impls::<dyn FloatTypeInterface>(&*opd_ty) {
-            return verify_err!(self.loc(ctx), FloatCastVerifyErr::OperandTypeErr);
-        };
-        let res_ty = res_ty.deref(ctx);
-        let Some(res_int_ty) = res_ty.downcast_ref::<IntegerType>() else {
+        let res_int_ty = ScalarOrVectorRes::<IntegerType, 0>::scalar_or_vector_elem_ty(self, ctx);
+        if !res_int_ty.deref(ctx).is_signless() {
             return verify_err!(self.loc(ctx), FloatCastVerifyErr::ResultTypeErr);
-        };
-        if !res_int_ty.is_signless() {
-            return verify_err!(self.loc(ctx), FloatCastVerifyErr::ResultTypeErr);
+        }
+        let opd_shape =
+            ScalarOrVectorOpdImpls::<dyn FloatTypeInterface, 0>::vector_shape(self, ctx);
+        let res_shape = ScalarOrVectorRes::<IntegerType, 0>::vector_shape(self, ctx);
+        if opd_shape != res_shape {
+            return verify_err!(self.loc(ctx), FloatCastVerifyErr::MismatchedVectorShape);
         }
         Ok(())
     }
@@ -3409,29 +3397,27 @@ impl Verify for FPToUIOp {
 #[pliron_op(
     name = "llvm.sitofp",
     format = "$0 ` to ` type($0)",
-    interfaces = [CastOpInterface, OneResultInterface, OneOpdInterface]
+    interfaces = [
+        CastOpInterface,
+        OneResultInterface,
+        OneOpdInterface,
+        ScalarOrVectorOpd<IntegerType, 0>,
+        ScalarOrVectorResImpls<dyn FloatTypeInterface, 0>,
+    ]
 )]
 pub struct SIToFPOp;
 
 impl Verify for SIToFPOp {
     fn verify(&self, ctx: &Context) -> Result<()> {
-        // Check that the operand is an integer and the result is a float
-        let (opd_ty, res_ty) = cast_element_types(
-            OneOpdInterface::operand_type(self, ctx),
-            OneResultInterface::result_type(self, ctx),
-            ctx,
-            self.loc(ctx),
-        )?;
-        let opd_ty = opd_ty.deref(ctx);
-        let Some(opd_ty_int) = opd_ty.downcast_ref::<IntegerType>() else {
-            return verify_err!(self.loc(ctx), FloatCastVerifyErr::OperandTypeErr);
-        };
-        if !opd_ty_int.is_signless() {
+        let opd_int_ty = ScalarOrVectorOpd::<IntegerType, 0>::scalar_or_vector_elem_ty(self, ctx);
+        if !opd_int_ty.deref(ctx).is_signless() {
             return verify_err!(self.loc(ctx), FloatCastVerifyErr::OperandTypeErr);
         }
-        let res_ty = res_ty.deref(ctx);
-        if !type_impls::<dyn FloatTypeInterface>(&*res_ty) {
-            return verify_err!(self.loc(ctx), FloatCastVerifyErr::ResultTypeErr);
+        let opd_shape = ScalarOrVectorOpd::<IntegerType, 0>::vector_shape(self, ctx);
+        let res_shape =
+            ScalarOrVectorResImpls::<dyn FloatTypeInterface, 0>::vector_shape(self, ctx);
+        if opd_shape != res_shape {
+            return verify_err!(self.loc(ctx), FloatCastVerifyErr::MismatchedVectorShape);
         }
         Ok(())
     }
@@ -3457,29 +3443,23 @@ impl Verify for SIToFPOp {
         OneOpdInterface,
         CastOpWithNNegInterface,
         NNegFlag,
+        ScalarOrVectorOpd<IntegerType, 0>,
+        ScalarOrVectorResImpls<dyn FloatTypeInterface, 0>,
     ]
 )]
 pub struct UIToFPOp;
 
 impl Verify for UIToFPOp {
     fn verify(&self, ctx: &Context) -> Result<()> {
-        // Check that the operand is an integer and the result is a float
-        let (opd_ty, res_ty) = cast_element_types(
-            OneOpdInterface::operand_type(self, ctx),
-            OneResultInterface::result_type(self, ctx),
-            ctx,
-            self.loc(ctx),
-        )?;
-        let opd_ty = opd_ty.deref(ctx);
-        let Some(opd_ty_int) = opd_ty.downcast_ref::<IntegerType>() else {
-            return verify_err!(self.loc(ctx), FloatCastVerifyErr::OperandTypeErr);
-        };
-        if !opd_ty_int.is_signless() {
+        let opd_int_ty = ScalarOrVectorOpd::<IntegerType, 0>::scalar_or_vector_elem_ty(self, ctx);
+        if !opd_int_ty.deref(ctx).is_signless() {
             return verify_err!(self.loc(ctx), FloatCastVerifyErr::OperandTypeErr);
         }
-        let res_ty = res_ty.deref(ctx);
-        if !type_impls::<dyn FloatTypeInterface>(&*res_ty) {
-            return verify_err!(self.loc(ctx), FloatCastVerifyErr::ResultTypeErr);
+        let opd_shape = ScalarOrVectorOpd::<IntegerType, 0>::vector_shape(self, ctx);
+        let res_shape =
+            ScalarOrVectorResImpls::<dyn FloatTypeInterface, 0>::vector_shape(self, ctx);
+        if opd_shape != res_shape {
+            return verify_err!(self.loc(ctx), FloatCastVerifyErr::MismatchedVectorShape);
         }
         Ok(())
     }
@@ -4077,28 +4057,11 @@ pub enum SelectOpVerifyErr {
         SameOperandsType,
         SameOperandsAndResultType,
         FastMathFlags,
-    ]
+        ScalarOrVectorOpdImpls<dyn FloatTypeInterface, 0>,
+    ],
+    verifier = "succ"
 )]
 pub struct FNegOp;
-
-impl Verify for FNegOp {
-    fn verify(&self, ctx: &Context) -> Result<()> {
-        use pliron::r#type::Typed;
-
-        let loc = self.loc(ctx);
-        let op = &*self.op.deref(ctx);
-        let mut arg_ty = op.get_operand(0).get_type(ctx);
-
-        if let Some(vec_ty) = arg_ty.deref(ctx).downcast_ref::<VectorType>() {
-            arg_ty = vec_ty.elem_type();
-        }
-
-        if !type_impls::<dyn FloatTypeInterface>(&*arg_ty.deref(ctx)) {
-            return verify_err!(loc, FNegOpVerifyErr::ArgumentMustBeFloat);
-        }
-        Ok(())
-    }
-}
 
 impl FNegOp {
     /// Create a new [FNegOp].
@@ -4120,14 +4083,6 @@ impl FNegOp {
         op.set_fast_math_flags(ctx, fast_math_flags);
         op
     }
-}
-
-#[derive(Error, Debug)]
-pub enum FNegOpVerifyErr {
-    #[error("Argument must be (possibly vector of) float")]
-    ArgumentMustBeFloat,
-    #[error("Fast math flags must be set")]
-    FastMathFlagsMustBeSet,
 }
 
 macro_rules! new_float_bin_op {
@@ -4153,6 +4108,7 @@ macro_rules! new_float_bin_op {
             interfaces = [
                 OneResultInterface, SameOperandsType, SameResultsType,
                 SameOperandsAndResultType, BinArithOp, FloatBinArithOp,
+                ScalarOrVectorOpdImpls<dyn FloatTypeInterface, 0>,
                 FloatBinArithOpWithFastMathFlags, FastMathFlags, NOpdsInterface<2>
             ],
             verifier = "succ"
@@ -4211,7 +4167,9 @@ new_float_bin_op! {
         OneResultInterface,
         SameOperandsType,
         FastMathFlags,
-        NOpdsInterface<2>
+        NOpdsInterface<2>,
+        ScalarOrVectorRes<IntegerType, 0>,
+        ScalarOrVectorOpdImpls<dyn FloatTypeInterface, 0>,
     ],
     attributes = (fcmp_predicate: FCmpPredicateAttr)
 )]
@@ -4256,33 +4214,16 @@ impl Verify for FCmpOp {
             verify_err!(loc.clone(), FCmpOpVerifyErr::PredAttrErr)?
         }
 
-        let mut res_ty = self.result_type(ctx);
-        let mut vec_num_elements = None;
-        if let Some(vec_ty) = res_ty.deref(ctx).downcast_ref::<VectorType>() {
-            res_ty = vec_ty.elem_type();
-            vec_num_elements = Some(vec_ty.num_elements());
-        }
-        let res_ty = res_ty.deref(ctx);
-        let Some(res_ty) = res_ty.downcast_ref::<IntegerType>() else {
-            return verify_err!(loc, FCmpOpVerifyErr::ResultNotBool);
-        };
-        if res_ty.width() != 1 {
+        let res_ty = ScalarOrVectorRes::<IntegerType, 0>::scalar_or_vector_elem_ty(self, ctx);
+        if res_ty.deref(ctx).width() != 1 {
             return verify_err!(loc, FCmpOpVerifyErr::ResultNotBool);
         }
 
-        let mut opd_ty = self.operand_type_i(ctx, I::<0>.into());
-        if let Some(vec_ty) = opd_ty.deref(ctx).downcast_ref::<VectorType>() {
-            opd_ty = vec_ty.elem_type();
-            // Ensure that the number of elements matches the result type's number of elements.
-            if vec_num_elements.is_none_or(|num_elements| vec_ty.num_elements() != num_elements) {
-                return verify_err!(loc, FCmpOpVerifyErr::MismatchedVectorNumElements);
-            }
-        } else if vec_num_elements.is_some() {
+        let res_shape = ScalarOrVectorRes::<IntegerType, 0>::vector_shape(self, ctx);
+        let opd_shape =
+            ScalarOrVectorOpdImpls::<dyn FloatTypeInterface, 0>::vector_shape(self, ctx);
+        if res_shape != opd_shape {
             return verify_err!(loc, FCmpOpVerifyErr::MismatchedVectorNumElements);
-        }
-        let opd_ty = opd_ty.deref(ctx);
-        if !type_impls::<dyn FloatTypeInterface>(&*opd_ty) {
-            return verify_err!(loc, FCmpOpVerifyErr::IncorrectOperandsType);
         }
 
         Ok(())
@@ -4293,8 +4234,6 @@ impl Verify for FCmpOp {
 pub enum FCmpOpVerifyErr {
     #[error("Result must be (possibly vector of) 1-bit integer (bool)")]
     ResultNotBool,
-    #[error("Operand must be (possibly vector of) floating point types")]
-    IncorrectOperandsType,
     #[error("Missing or incorrect predicate attribute")]
     PredAttrErr,
     #[error("Vector operand and result types must have the same number of elements")]

--- a/src/builtin/op_interfaces.rs
+++ b/src/builtin/op_interfaces.rs
@@ -997,9 +997,20 @@ pub trait AllOperandsOfType<T: Type> {
 }
 
 #[derive(Error, Debug)]
+#[error("Op has only {0} operands, but expected at least {1}")]
+pub struct NotEnoughOperandsErr(pub usize, pub usize);
+
+/// Verify that `op` has an operand at index `N` (0-indexed).
+pub fn verify_get_operand_n<const N: usize>(op: Ptr<Operation>, ctx: &Context) -> Result<Value> {
+    let opr = op.deref(ctx);
+    if opr.get_num_operands() <= N {
+        return verify_err!(opr.loc(), NotEnoughOperandsErr(opr.get_num_operands(), N));
+    }
+    Ok(opr.get_operand(N))
+}
+
+#[derive(Error, Debug)]
 pub enum OperandNOfTypeError {
-    #[error("Op has only {} operands, but expected at least {}", .0, .1)]
-    NotEnoughOperands(usize, usize),
     #[error("Expected operand type {0}, but found {1}")]
     AllOperandsOfTypeVerifyErr(String, String),
 }
@@ -1011,18 +1022,11 @@ pub trait OperandNOfType<const N: usize, T: Type> {
     where
         Self: Sized,
     {
-        let op = op.get_operation().deref(ctx);
-        if op.get_num_operands() <= N {
-            return verify_err!(
-                op.loc(),
-                OperandNOfTypeError::NotEnoughOperands(op.get_num_operands(), N)
-            );
-        }
-        let opd_n = op.get_operand(N);
+        let opd_n = verify_get_operand_n::<N>(op.get_operation(), ctx)?;
         let opd_n_ty = &*opd_n.get_type(ctx).deref(ctx);
         if !opd_n_ty.as_any().is::<T>() {
             return verify_err!(
-                op.loc(),
+                op.loc(ctx),
                 OperandNOfTypeError::AllOperandsOfTypeVerifyErr(
                     T::get_type_id_static().disp(ctx).to_string(),
                     opd_n_ty.get_type_id().disp(ctx).to_string()
@@ -1095,9 +1099,20 @@ pub trait AllResultsOfType<T: Type> {
 }
 
 #[derive(Error, Debug)]
+#[error("Op has only {0} results, but expected at least {1}")]
+pub struct NotEnoughResultsErr(pub usize, pub usize);
+
+/// Verify that `op` has a result at index `N` (0-indexed).
+pub fn verify_get_result_n<const N: usize>(op: Ptr<Operation>, ctx: &Context) -> Result<Value> {
+    let opr = op.deref(ctx);
+    if opr.get_num_results() <= N {
+        return verify_err!(opr.loc(), NotEnoughResultsErr(opr.get_num_results(), N));
+    }
+    Ok(opr.get_result(N))
+}
+
+#[derive(Error, Debug)]
 pub enum ResultNOfTypeError {
-    #[error("Op has only {} results, but expected at least {}", .0, .1)]
-    NotEnoughResults(usize, usize),
     #[error("Expected result type {0}, but found {1}")]
     AllResultsOfTypeVerifyErr(String, String),
 }
@@ -1109,18 +1124,11 @@ pub trait ResultNOfType<const N: usize, T: Type> {
     where
         Self: Sized,
     {
-        let op = op.get_operation().deref(ctx);
-        if op.get_num_results() <= N {
-            return verify_err!(
-                op.loc(),
-                ResultNOfTypeError::NotEnoughResults(op.get_num_results(), N)
-            );
-        }
-        let res_n = op.get_result(N);
+        let res_n = verify_get_result_n::<N>(op.get_operation(), ctx)?;
         let res_n_ty = &*res_n.get_type(ctx).deref(ctx);
         if !res_n_ty.as_any().is::<T>() {
             return verify_err!(
-                op.loc(),
+                op.loc(ctx),
                 ResultNOfTypeError::AllResultsOfTypeVerifyErr(
                     T::get_type_id_static().disp(ctx).to_string(),
                     res_n_ty.get_type_id().disp(ctx).to_string()


### PR DESCRIPTION
Factor the repeated "operand/result is T, or a vector of T" checks scattered across icmp, fcmp, casts, and binary arithmetic ops into reusable ScalarOrVectorOpd/Res (and *Impls for interface-typed element constraints) op-interfaces.

As part of this, sext/zext/trunc now also verify that operand and result vector shapes match, which was previously unchecked.
