### PR TITLE
feat: add non temporal interface

### DIFF
--- a/pliron-llvm/src/llvm_sys/core.rs
+++ b/pliron-llvm/src/llvm_sys/core.rs
@@ -48,29 +48,27 @@ use llvm_sys::{
         LLVMGetIncomingValue, LLVMGetIndices, LLVMGetInitializer, LLVMGetInsertBlock,
         LLVMGetInstructionOpcode, LLVMGetInstructionParent, LLVMGetIntTypeWidth,
         LLVMGetIntrinsicDeclaration, LLVMGetLastFunction, LLVMGetLastGlobal, LLVMGetLinkage,
-        LLVMGetMaskValue, LLVMGetModuleIdentifier, LLVMGetNNeg, LLVMGetNSW, LLVMGetNUW,
-        LLVMGetNamedFunction, LLVMGetNamedGlobal, LLVMGetNextBasicBlock, LLVMGetNextFunction,
-        LLVMGetNextGlobal, LLVMGetNextInstruction, LLVMGetNextParam, LLVMGetNumArgOperands,
-        LLVMGetNumIndices, LLVMGetNumMaskElements, LLVMGetNumOperands, LLVMGetOperand,
-        LLVMGetParam, LLVMGetParamTypes, LLVMGetPointerAddressSpace, LLVMGetPoison,
+        LLVMGetMDKindIDInContext, LLVMGetMaskValue, LLVMGetModuleIdentifier, LLVMGetNNeg,
+        LLVMGetNSW, LLVMGetNUW, LLVMGetNamedFunction, LLVMGetNamedGlobal, LLVMGetNextBasicBlock,
+        LLVMGetNextFunction, LLVMGetNextGlobal, LLVMGetNextInstruction, LLVMGetNextParam,
+        LLVMGetNumArgOperands, LLVMGetNumIndices, LLVMGetNumMaskElements, LLVMGetNumOperands,
+        LLVMGetOperand, LLVMGetParam, LLVMGetParamTypes, LLVMGetPointerAddressSpace, LLVMGetPoison,
         LLVMGetPreviousBasicBlock, LLVMGetPreviousFunction, LLVMGetPreviousGlobal,
         LLVMGetPreviousInstruction, LLVMGetPreviousParam, LLVMGetReturnType,
         LLVMGetStructElementTypes, LLVMGetStructName, LLVMGetSwitchCaseValue, LLVMGetTypeKind,
-        LLVMGetMDKindIDInContext, LLVMGetUndef, LLVMGetUndefMaskElem, LLVMGetValueKind,
-        LLVMGetValueName2, LLVMGetVectorSize,
+        LLVMGetUndef, LLVMGetUndefMaskElem, LLVMGetValueKind, LLVMGetValueName2, LLVMGetVectorSize,
         LLVMGlobalGetValueType, LLVMHalfTypeInContext, LLVMInstructionEraseFromParent,
         LLVMIntTypeInContext, LLVMIntrinsicIsOverloaded, LLVMIsAFunction, LLVMIsATerminatorInst,
         LLVMIsAUser, LLVMIsConstantString, LLVMIsDeclaration, LLVMIsFunctionVarArg,
         LLVMIsOpaqueStruct, LLVMIsPackedStruct, LLVMLookupIntrinsicID, LLVMMDNodeInContext2,
-        LLVMMetadataAsValue,
-        LLVMModuleCreateWithNameInContext, LLVMPointerTypeInContext, LLVMPositionBuilderAtEnd,
-        LLVMPositionBuilderBefore, LLVMPrintModuleToFile, LLVMPrintModuleToString,
-        LLVMPrintTypeToString, LLVMPrintValueToString, LLVMReplaceAllUsesWith,
-        LLVMScalableVectorType, LLVMSetAlignment, LLVMSetFastMathFlags, LLVMSetInitializer,
-        LLVMSetLinkage, LLVMSetMetadata, LLVMSetNNeg, LLVMStructCreateNamed, LLVMStructSetBody,
-        LLVMStructTypeInContext, LLVMTypeIsSized, LLVMTypeOf, LLVMValueAsBasicBlock,
-        LLVMValueAsMetadata,
-        LLVMValueIsBasicBlock, LLVMVectorType, LLVMVoidTypeInContext,
+        LLVMMetadataAsValue, LLVMModuleCreateWithNameInContext, LLVMPointerTypeInContext,
+        LLVMPositionBuilderAtEnd, LLVMPositionBuilderBefore, LLVMPrintModuleToFile,
+        LLVMPrintModuleToString, LLVMPrintTypeToString, LLVMPrintValueToString,
+        LLVMReplaceAllUsesWith, LLVMScalableVectorType, LLVMSetAlignment, LLVMSetFastMathFlags,
+        LLVMSetInitializer, LLVMSetLinkage, LLVMSetMetadata, LLVMSetNNeg, LLVMStructCreateNamed,
+        LLVMStructSetBody, LLVMStructTypeInContext, LLVMTypeIsSized, LLVMTypeOf,
+        LLVMValueAsBasicBlock, LLVMValueAsMetadata, LLVMValueIsBasicBlock, LLVMVectorType,
+        LLVMVoidTypeInContext,
     },
     error::{LLVMDisposeErrorMessage, LLVMErrorRef, LLVMGetErrorMessage},
     prelude::{
@@ -1125,11 +1123,7 @@ pub fn llvm_set_non_temporal(context: &LLVMContext, val: LLVMValue) {
             KIND.len() as u32,
         );
         let mut operands = [LLVMValueAsMetadata(one.into())];
-        let node = LLVMMDNodeInContext2(
-            context.inner_ref(),
-            operands.as_mut_ptr(),
-            operands.len(),
-        );
+        let node = LLVMMDNodeInContext2(context.inner_ref(), operands.as_mut_ptr(), operands.len());
         let node = LLVMMetadataAsValue(context.inner_ref(), node);
         LLVMSetMetadata(val.into(), kind_id, node);
     }

--- a/pliron-llvm/src/llvm_sys/core.rs
+++ b/pliron-llvm/src/llvm_sys/core.rs
@@ -56,17 +56,20 @@ use llvm_sys::{
         LLVMGetPreviousBasicBlock, LLVMGetPreviousFunction, LLVMGetPreviousGlobal,
         LLVMGetPreviousInstruction, LLVMGetPreviousParam, LLVMGetReturnType,
         LLVMGetStructElementTypes, LLVMGetStructName, LLVMGetSwitchCaseValue, LLVMGetTypeKind,
-        LLVMGetUndef, LLVMGetUndefMaskElem, LLVMGetValueKind, LLVMGetValueName2, LLVMGetVectorSize,
+        LLVMGetMDKindIDInContext, LLVMGetUndef, LLVMGetUndefMaskElem, LLVMGetValueKind,
+        LLVMGetValueName2, LLVMGetVectorSize,
         LLVMGlobalGetValueType, LLVMHalfTypeInContext, LLVMInstructionEraseFromParent,
         LLVMIntTypeInContext, LLVMIntrinsicIsOverloaded, LLVMIsAFunction, LLVMIsATerminatorInst,
         LLVMIsAUser, LLVMIsConstantString, LLVMIsDeclaration, LLVMIsFunctionVarArg,
-        LLVMIsOpaqueStruct, LLVMIsPackedStruct, LLVMLookupIntrinsicID,
+        LLVMIsOpaqueStruct, LLVMIsPackedStruct, LLVMLookupIntrinsicID, LLVMMDNodeInContext2,
+        LLVMMetadataAsValue,
         LLVMModuleCreateWithNameInContext, LLVMPointerTypeInContext, LLVMPositionBuilderAtEnd,
         LLVMPositionBuilderBefore, LLVMPrintModuleToFile, LLVMPrintModuleToString,
         LLVMPrintTypeToString, LLVMPrintValueToString, LLVMReplaceAllUsesWith,
         LLVMScalableVectorType, LLVMSetAlignment, LLVMSetFastMathFlags, LLVMSetInitializer,
-        LLVMSetLinkage, LLVMSetNNeg, LLVMStructCreateNamed, LLVMStructSetBody,
+        LLVMSetLinkage, LLVMSetMetadata, LLVMSetNNeg, LLVMStructCreateNamed, LLVMStructSetBody,
         LLVMStructTypeInContext, LLVMTypeIsSized, LLVMTypeOf, LLVMValueAsBasicBlock,
+        LLVMValueAsMetadata,
         LLVMValueIsBasicBlock, LLVMVectorType, LLVMVoidTypeInContext,
     },
     error::{LLVMDisposeErrorMessage, LLVMErrorRef, LLVMGetErrorMessage},
@@ -1107,6 +1110,29 @@ pub fn llvm_set_alignment(val: LLVMValue, align: u32) {
             || llvm_is_a::store_inst(val)
     );
     unsafe { LLVMSetAlignment(val.into(), align) }
+}
+
+/// Attach LLVM's `!nontemporal` metadata to a load or store instruction.
+pub fn llvm_set_non_temporal(context: &LLVMContext, val: LLVMValue) {
+    assert!(llvm_is_a::load_inst(val) || llvm_is_a::store_inst(val));
+    const KIND: &str = "nontemporal";
+    // The metadata node is `!{i32 1}`, as LLVM expects for the `!nontemporal` hint.
+    let one = llvm_const_int(llvm_int_type_in_context(context, 32), 1, false);
+    unsafe {
+        let kind_id = LLVMGetMDKindIDInContext(
+            context.inner_ref(),
+            to_c_str(KIND).as_ptr(),
+            KIND.len() as u32,
+        );
+        let mut operands = [LLVMValueAsMetadata(one.into())];
+        let node = LLVMMDNodeInContext2(
+            context.inner_ref(),
+            operands.as_mut_ptr(),
+            operands.len(),
+        );
+        let node = LLVMMetadataAsValue(context.inner_ref(), node);
+        LLVMSetMetadata(val.into(), kind_id, node);
+    }
 }
 
 /// LLVMGetNumMaskElements

--- a/pliron-llvm/src/op_interfaces.rs
+++ b/pliron-llvm/src/op_interfaces.rs
@@ -10,7 +10,7 @@ use alloc::{
 
 use pliron::{
     builtin::{
-        attributes::BoolAttr,
+        attributes::{BoolAttr, UnitAttr},
         op_interfaces::{
             NOpdsInterface, OneOpdInterface, ResultNOfType, SymbolOpInterface,
             verify_get_operand_n, verify_get_result_n,
@@ -475,6 +475,49 @@ pub trait AlignableOpInterface {
             .deref_mut(ctx)
             .attributes
             .set(ATTR_KEY_LLVM_ALIGNMENT.clone(), AlignmentAttr(alignment));
+    }
+
+    fn verify(_op: &dyn Op, _ctx: &Context) -> Result<()>
+    where
+        Self: Sized,
+    {
+        Ok(())
+    }
+}
+
+dict_key!(
+    /// Attribute key for the non-temporal hint.
+    ATTR_KEY_LLVM_NON_TEMPORAL,
+    "llvm_non_temporal"
+);
+
+/// Ops that can be marked non-temporal, i.e. LLVM's `!nontemporal` metadata.
+///
+/// The hint tells the backend that the accessed data is unlikely to be reused soon, so it may
+/// bypass the cache. It is only a hint: backends that cannot honor it emit an ordinary access.
+#[op_interface]
+pub trait NonTemporalOpInterface {
+    /// Whether this [Op] is marked non-temporal.
+    fn is_non_temporal(&self, ctx: &Context) -> bool
+    where
+        Self: Sized,
+    {
+        self.get_operation()
+            .deref(ctx)
+            .attributes
+            .get::<UnitAttr>(&ATTR_KEY_LLVM_NON_TEMPORAL)
+            .is_some()
+    }
+
+    /// Mark this [Op] as non-temporal.
+    fn set_non_temporal(&self, ctx: &Context)
+    where
+        Self: Sized,
+    {
+        self.get_operation()
+            .deref_mut(ctx)
+            .attributes
+            .set(ATTR_KEY_LLVM_NON_TEMPORAL.clone(), UnitAttr::new());
     }
 
     fn verify(_op: &dyn Op, _ctx: &Context) -> Result<()>

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -68,8 +68,8 @@ use crate::{
         AlignableOpInterface, BinArithOp, CastOpInterface, CastOpWithNNegInterface, FastMathFlags,
         FloatBinArithOp, FloatBinArithOpWithFastMathFlags, IntBinArithOp,
         IntBinArithOpWithOverflowFlag, IsDeclaration, LlvmSymbolName, NNegFlag,
-        NonTemporalOpInterface, PointerTypeResult,
-        ScalarOrVectorOpd, ScalarOrVectorOpdImpls, ScalarOrVectorRes, ScalarOrVectorResImpls,
+        NonTemporalOpInterface, PointerTypeResult, ScalarOrVectorOpd, ScalarOrVectorOpdImpls,
+        ScalarOrVectorRes, ScalarOrVectorResImpls,
     },
     ops::{
         func_op_attr_names::ATTR_KEY_LLVM_FUNC_TYPE,

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -18,7 +18,7 @@ use pliron::{
     basic_block::BasicBlock,
     builtin::{
         attr_interfaces::{FloatAttr, TypedAttrInterface},
-        attributes::{BoolAttr, IdentifierAttr, IntegerAttr, StringAttr, TypeAttr},
+        attributes::{BoolAttr, IdentifierAttr, IntegerAttr, StringAttr, TypeAttr, UnitAttr},
         op_interfaces::{
             self, ATTR_KEY_SYM_NAME, AtMostNRegionsInterface, AtMostOneRegionInterface,
             BranchOpInterface, CallOpCallable, CallOpInterface, IsTerminatorInterface,
@@ -67,7 +67,8 @@ use crate::{
     op_interfaces::{
         AlignableOpInterface, BinArithOp, CastOpInterface, CastOpWithNNegInterface, FastMathFlags,
         FloatBinArithOp, FloatBinArithOpWithFastMathFlags, IntBinArithOp,
-        IntBinArithOpWithOverflowFlag, IsDeclaration, LlvmSymbolName, NNegFlag, PointerTypeResult,
+        IntBinArithOpWithOverflowFlag, IsDeclaration, LlvmSymbolName, NNegFlag,
+        NonTemporalOpInterface, PointerTypeResult,
         ScalarOrVectorOpd, ScalarOrVectorOpdImpls, ScalarOrVectorRes, ScalarOrVectorResImpls,
     },
     ops::{
@@ -1679,10 +1680,11 @@ pub enum StoreOpVerifyErr {
 /// | `value` | Sized type |
 #[pliron_op(
     name = "llvm.store",
-    format = "`*` $1 ` <- ` $0 ` ` opt_attr($llvm_alignment, $AlignmentAttr, label($align), delimiters(`[`, `]`))",
+    format = "`*` $1 ` <- ` $0 ` ` opt_attr($llvm_alignment, $AlignmentAttr, label($align), delimiters(`[`, `]`)) opt_attr($llvm_non_temporal, $UnitAttr, label($nontemporal))",
     interfaces = [
         NResultsInterface<0>,
         AlignableOpInterface,
+        NonTemporalOpInterface,
         NOpdsInterface<2>
     ],
     operands = (value, address: PointerType),

--- a/pliron-llvm/src/to_llvm_ir.rs
+++ b/pliron-llvm/src/to_llvm_ir.rs
@@ -77,13 +77,14 @@ use crate::{
         llvm_int_type_in_context, llvm_is_a, llvm_lookup_intrinsic_id,
         llvm_pointer_type_in_context, llvm_position_builder_at_end, llvm_replace_all_uses_with,
         llvm_scalable_vector_type, llvm_set_alignment, llvm_set_atomic_sync_scope_id,
+        llvm_set_non_temporal,
         llvm_set_fast_math_flags, llvm_set_initializer, llvm_set_linkage, llvm_set_nneg,
         llvm_set_ordering, llvm_struct_create_named, llvm_struct_set_body,
         llvm_struct_type_in_context, llvm_type_of, llvm_vector_type, llvm_void_type_in_context,
     },
     op_interfaces::{
         AlignableOpInterface, FastMathFlags, IsDeclaration, LlvmSymbolName, NNegFlag,
-        PointerTypeResult,
+        NonTemporalOpInterface, PointerTypeResult,
     },
     ops::{
         AShrOp, AddOp, AddrSpaceCastOp, AddressOfOp, AllocaOp, AndOp, AtomicCmpxchgOp,
@@ -819,7 +820,7 @@ impl ToLLVMValue for StoreOp {
     fn convert(
         &self,
         ctx: &Context,
-        _llvm_ctx: &LLVMContext,
+        llvm_ctx: &LLVMContext,
         cctx: &mut ConversionContext,
     ) -> Result<LLVMValue> {
         let value = convert_value_operand(cctx, ctx, &self.get_operand_value(ctx))?;
@@ -827,6 +828,9 @@ impl ToLLVMValue for StoreOp {
         let store_op = llvm_build_store(&cctx.builder, value, ptr);
         if let Some(alignment) = self.alignment(ctx) {
             llvm_set_alignment(store_op, alignment);
+        }
+        if self.is_non_temporal(ctx) {
+            llvm_set_non_temporal(llvm_ctx, store_op);
         }
         Ok(store_op)
     }

--- a/pliron-llvm/src/to_llvm_ir.rs
+++ b/pliron-llvm/src/to_llvm_ir.rs
@@ -77,9 +77,8 @@ use crate::{
         llvm_int_type_in_context, llvm_is_a, llvm_lookup_intrinsic_id,
         llvm_pointer_type_in_context, llvm_position_builder_at_end, llvm_replace_all_uses_with,
         llvm_scalable_vector_type, llvm_set_alignment, llvm_set_atomic_sync_scope_id,
-        llvm_set_non_temporal,
         llvm_set_fast_math_flags, llvm_set_initializer, llvm_set_linkage, llvm_set_nneg,
-        llvm_set_ordering, llvm_struct_create_named, llvm_struct_set_body,
+        llvm_set_non_temporal, llvm_set_ordering, llvm_struct_create_named, llvm_struct_set_body,
         llvm_struct_type_in_context, llvm_type_of, llvm_vector_type, llvm_void_type_in_context,
     },
     op_interfaces::{

--- a/pliron-llvm/tests/common/mod.rs
+++ b/pliron-llvm/tests/common/mod.rs
@@ -3,6 +3,7 @@
 use pliron::{
     builtin::ops::ModuleOp,
     context::Context,
+    graph::walkers::{IRNode, WALKCONFIG_PREORDER_FORWARD, uninterruptible::immutable::walk_op},
     irfmt::parsers::spaced,
     op::{Op, verify_op},
     operation::{Operation, verify_operation},
@@ -44,6 +45,26 @@ pub fn run_o1_passes_verify(ctx: &mut Context, module_op: ModuleOp) -> Result<()
     );
     verify_op(&module_op, ctx)?;
     Ok(())
+}
+
+/// Returns the first [Op] of type `O` found under `root`, if any.
+#[allow(dead_code)]
+pub fn find_op<O: Op>(ctx: &Context, root: impl Op) -> Option<O> {
+    let mut found: Option<O> = None;
+    walk_op(
+        ctx,
+        &mut found,
+        &WALKCONFIG_PREORDER_FORWARD,
+        root.get_operation(),
+        |ctx, found: &mut Option<O>, node| {
+            if found.is_none()
+                && let IRNode::Operation(op) = node
+            {
+                *found = Operation::get_op::<O>(op, ctx);
+            }
+        },
+    );
+    found
 }
 
 /// Parses `input` as LLVM IR text, converts it into a pliron [ModuleOp], and verifies it.

--- a/pliron-llvm/tests/ir_expect.rs
+++ b/pliron-llvm/tests/ir_expect.rs
@@ -6,8 +6,13 @@
 #![cfg(feature = "llvm-sys")]
 
 use expect_test::expect;
-use pliron::{context::Context, init_env_logger_for_tests, printable::Printable, result::Result};
-use pliron_llvm::{llvm_sys::core::LLVMContext, to_llvm_ir};
+use pliron::{
+    builtin::ops::ModuleOp, context::Context, init_env_logger_for_tests, printable::Printable,
+    result::Result,
+};
+use pliron_llvm::{
+    llvm_sys::core::LLVMContext, op_interfaces::NonTemporalOpInterface, ops::StoreOp, to_llvm_ir,
+};
 
 mod common;
 
@@ -241,5 +246,60 @@ fn llvm_ir_struct_combinations_roundtrip() -> Result<()> {
         }
     "#]]
     .assert_eq(&out);
+    Ok(())
+}
+
+/// A store marked non-temporal must carry LLVM's `!nontemporal` metadata, and the
+/// mark must survive a print/parse round trip of the pliron IR.
+#[test]
+fn non_temporal_store_emits_metadata() -> Result<()> {
+    init_env_logger_for_tests!();
+
+    let input = r#"
+        define void @stream(ptr %out, <8 x float> %val) {
+        entry:
+          store <8 x float> %val, ptr %out, align 4
+          ret void
+        }
+    "#;
+
+    let llvm_ctx = LLVMContext::default();
+    let ctx = &mut Context::new();
+    let module_op = common::parse_llvm_ir_verify(ctx, &llvm_ctx, input, "stream")?;
+
+    let store = common::find_op::<StoreOp>(ctx, module_op).expect("module has a store");
+    assert!(!store.is_non_temporal(ctx));
+    store.set_non_temporal(ctx);
+    assert!(store.is_non_temporal(ctx));
+
+    // The mark is part of the printed form, so it round trips through the text format.
+    let printed = module_op.disp(ctx).to_string();
+    assert!(
+        printed.contains("nontemporal"),
+        "non-temporal mark missing from printed IR:\n{printed}"
+    );
+    let reparsed_ctx = &mut Context::new();
+    let reparsed: ModuleOp = common::parse_op_verify(reparsed_ctx, &printed)?;
+    let reparsed_store =
+        common::find_op::<StoreOp>(reparsed_ctx, reparsed).expect("module has a store");
+    assert!(reparsed_store.is_non_temporal(reparsed_ctx));
+
+    let out_llvm_ctx = LLVMContext::default();
+    let out_mod = to_llvm_ir::convert_module(ctx, &out_llvm_ctx, module_op)?;
+    let out = out_mod.to_string();
+    expect![[r#"
+        ; ModuleID = 'stream'
+        source_filename = "stream"
+
+        define void @stream(ptr %0, <8 x float> %1) {
+        entry_block2v1:
+          store <8 x float> %1, ptr %0, align 4, !nontemporal !0
+          ret void
+        }
+
+        !0 = !{i32 1}
+    "#]]
+    .assert_eq(&out);
+
     Ok(())
 }


### PR DESCRIPTION
## Description

This PR add a way to create non temporal load and store that are necessary to improve throughput of store operation when they are not read back immediately after

## Checklist
- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [X] A human is involved in writing this PR description and will handle
review interactions, per our [AI tool policy](../CONTRIBUTING.md).
- [X] I understand every part of this change (including any AI-generated
code) and can explain the reasoning behind it.
- [X] Intrusive / large changes were discussed on Discord before this PR.
- [X] `pre-ci.sh` passes locally.
