### PR TITLE
Preserve GEP no-wrap flags across LLVM IR conversion

### DIFF
--- a/pliron-llvm/src/attributes.rs
+++ b/pliron-llvm/src/attributes.rs
@@ -130,6 +130,111 @@ impl Parsable for FastmathFlagsAttr {
     }
 }
 
+bitflags! {
+    /// No-wrap flags for getelementptr operations.
+    #[derive(PartialEq, Eq, Clone, Debug, Hash, Copy)]
+    pub struct GepNoWrapFlags: u8 {
+        const INBOUNDS = 1;
+        const NUSW = 2;
+        const NUW = 4;
+    }
+}
+
+impl GepNoWrapFlags {
+    /// Normalize flags to LLVM semantics: `inbounds` implies `nusw`.
+    pub fn normalized(self) -> Self {
+        if self.contains(Self::INBOUNDS) {
+            self | Self::NUSW
+        } else {
+            self
+        }
+    }
+}
+
+#[pliron_attr(name = "llvm.gep_no_wrap_flags", verifier = "succ")]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+pub struct GepNoWrapFlagsAttr(pub GepNoWrapFlags);
+
+impl Default for GepNoWrapFlagsAttr {
+    fn default() -> Self {
+        Self(GepNoWrapFlags::empty())
+    }
+}
+
+impl From<GepNoWrapFlags> for GepNoWrapFlagsAttr {
+    fn from(value: GepNoWrapFlags) -> Self {
+        Self(value.normalized())
+    }
+}
+
+impl From<GepNoWrapFlagsAttr> for GepNoWrapFlags {
+    fn from(attr: GepNoWrapFlagsAttr) -> Self {
+        attr.0
+    }
+}
+
+impl Display for GepNoWrapFlagsAttr {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let flags = self.0.normalized();
+        write!(f, "<")?;
+        let mut first = true;
+        let mut emit = |name: &str| -> core::fmt::Result {
+            if !first {
+                write!(f, " | ")?;
+            }
+            first = false;
+            write!(f, "{name}")
+        };
+        if flags.contains(GepNoWrapFlags::INBOUNDS) {
+            emit("INBOUNDS")?;
+        } else if flags.contains(GepNoWrapFlags::NUSW) {
+            emit("NUSW")?;
+        }
+        if flags.contains(GepNoWrapFlags::NUW) {
+            emit("NUW")?;
+        }
+        write!(f, ">")
+    }
+}
+
+impl_printable_for_display!(GepNoWrapFlagsAttr);
+
+#[derive(Debug, Error)]
+#[error("Error parsing GEP no-wrap flags: {0}")]
+pub struct GepNoWrapFlagParseErr(pub bitflags::parser::ParseError);
+
+impl Parsable for GepNoWrapFlagsAttr {
+    type Arg = ();
+    type Parsed = Self;
+
+    fn parse<'a>(
+        state_stream: &mut pliron::parsable::StateStream<'a>,
+        _arg: Self::Arg,
+    ) -> pliron::parsable::ParseResult<'a, Self::Parsed> {
+        let pos = state_stream.loc();
+        let allowed_chars = combine::choice!(
+            combine::parser::char::space().map(|c| c.to_string()),
+            combine::parser::char::alpha_num().map(|c| c.to_string()),
+            combine::parser::char::char('|').map(|c: char| c.to_string())
+        );
+
+        let (parsed, _): (Vec<String>, _) = combine::between(
+            combine::parser::char::char('<').with(spaces()),
+            spaces().with(combine::parser::char::char('>')),
+            combine::many(allowed_chars),
+        )
+        .parse_stream(state_stream)
+        .into_result()?;
+        let parsed_string = parsed.concat();
+
+        let (flags, _) = bitflags::parser::from_str::<GepNoWrapFlags>(&parsed_string)
+            .map_err(|e| input_error!(pos.clone(), GepNoWrapFlagParseErr(e)))
+            .into_parse_result()?;
+
+        Ok(GepNoWrapFlagsAttr(flags.normalized())).into_parse_result()
+    }
+}
+
 #[pliron_attr(name = "llvm.icmp_predicate", verifier = "succ", format)]
 #[derive(PartialEq, Eq, Clone, Debug, Hash)]
 pub enum ICmpPredicateAttr {
@@ -435,6 +540,55 @@ mod tests {
                     Compilation error: invalid input program.
                     Parse error at line: 1, column: 1
                     Error parsing fastmath flags: unrecognized named flag `INVALIDFLAG`
+                "#]]
+                .assert_eq(&e.to_string());
+            }
+        }
+    }
+
+    #[test]
+    fn test_gep_no_wrap_flags_attr_fmt() {
+        let ctx = &Context::default();
+
+        let flags: GepNoWrapFlagsAttr = (GepNoWrapFlags::NUSW | GepNoWrapFlags::NUW).into();
+        expect!["<NUSW | NUW>"].assert_eq(&flags.disp(ctx).to_string());
+
+        let flags: GepNoWrapFlagsAttr = (GepNoWrapFlags::INBOUNDS | GepNoWrapFlags::NUW).into();
+        expect!["<INBOUNDS | NUW>"].assert_eq(&flags.disp(ctx).to_string());
+    }
+
+    #[test]
+    fn test_gep_no_wrap_flags_inbounds_implies_nusw() {
+        let flags: GepNoWrapFlagsAttr = GepNoWrapFlags::INBOUNDS.into();
+
+        assert!(flags.0.contains(GepNoWrapFlags::INBOUNDS));
+        assert!(flags.0.contains(GepNoWrapFlags::NUSW));
+    }
+
+    #[test]
+    fn test_gep_no_wrap_flags_attr_parse_valid() {
+        let ctx = &mut Context::default();
+
+        let parsed =
+            parse_from_str(GepNoWrapFlagsAttr::parser(()), ctx, "<INBOUNDS | NUW>").expect_ok(ctx);
+        assert!(parsed.0.contains(GepNoWrapFlags::INBOUNDS));
+        assert!(parsed.0.contains(GepNoWrapFlags::NUSW));
+        assert!(parsed.0.contains(GepNoWrapFlags::NUW));
+    }
+
+    #[test]
+    fn test_gep_no_wrap_flags_attr_parse_invalid() {
+        let ctx = &mut Context::default();
+        let input = "<INVALIDFLAG>";
+        match parse_from_str(GepNoWrapFlagsAttr::parser(()), ctx, input) {
+            Ok(parsed) => {
+                panic!("Expected error, but got: {}", parsed);
+            }
+            Err(e) => {
+                expect![[r#"
+                    Compilation error: invalid input program.
+                    Parse error at line: 1, column: 1
+                    Error parsing GEP no-wrap flags: unrecognized named flag `INVALIDFLAG`
                 "#]]
                 .assert_eq(&e.to_string());
             }

--- a/pliron-llvm/src/attributes.rs
+++ b/pliron-llvm/src/attributes.rs
@@ -848,7 +848,7 @@ mod tests {
             Parse error at line: 1, column: 1
             Error parsing GEP no-wrap flags: unrecognized named flag `INVALIDFLAG`
         "#]]
-            .assert_eq(&err.to_string());
+        .assert_eq(&err.to_string());
     }
 
     fn assert_attr_roundtrips<A>(ctx: &mut Context, attr: A)

--- a/pliron-llvm/src/attributes.rs
+++ b/pliron-llvm/src/attributes.rs
@@ -186,8 +186,7 @@ impl Display for GepNoWrapFlagsAttr {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut flags = self.0.normalized();
 
-        // `inbounds` implies `nusw`, but LLVM prints the implied `nusw`
-        // implicitly rather than redundantly.
+        // `inbounds` implies `nusw`
         if flags.contains(GepNoWrapFlags::INBOUNDS) {
             flags.remove(GepNoWrapFlags::NUSW);
         }
@@ -844,28 +843,12 @@ mod tests {
 
         let err = parse_from_str(GepNoWrapFlagsAttr::parser(()), ctx, input)
             .expect_err("invalid GEP no-wrap flag must fail to parse");
-        let parse_errors = err
-            .err
-            .downcast_ref::<pliron::combine::easy::Errors<
-                char,
-                char,
-                pliron::combine::stream::position::SourcePosition,
-            >>()
-            .expect("expected combine parser errors");
-
-        let parse_err = parse_errors
-            .errors
-            .iter()
-            .find_map(|err| match err {
-                pliron::combine::easy::Error::Other(err) => {
-                    err.downcast_ref::<GepNoWrapFlagParseErr>()
-                }
-                _ => None,
-            })
-            .expect("expected GepNoWrapFlagParseErr");
-
-        expect!["Error parsing GEP no-wrap flags: unrecognized named flag `INVALIDFLAG`"]
-            .assert_eq(&parse_err.to_string());
+        expect![[r#"
+            Compilation error: invalid input program.
+            Parse error at line: 1, column: 1
+            Error parsing GEP no-wrap flags: unrecognized named flag `INVALIDFLAG`
+        "#]]
+            .assert_eq(&err.to_string());
     }
 
     fn assert_attr_roundtrips<A>(ctx: &mut Context, attr: A)

--- a/pliron-llvm/src/attributes.rs
+++ b/pliron-llvm/src/attributes.rs
@@ -175,24 +175,16 @@ impl From<GepNoWrapFlagsAttr> for GepNoWrapFlags {
 
 impl Display for GepNoWrapFlagsAttr {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let flags = self.0.normalized();
-        write!(f, "<")?;
-        let mut first = true;
-        let mut emit = |name: &str| -> core::fmt::Result {
-            if !first {
-                write!(f, " | ")?;
-            }
-            first = false;
-            write!(f, "{name}")
-        };
+        let mut flags = self.0.normalized();
+
+        // `inbounds` implies `nusw`, but LLVM prints the implied `nusw`
+        // implicitly rather than redundantly.
         if flags.contains(GepNoWrapFlags::INBOUNDS) {
-            emit("INBOUNDS")?;
-        } else if flags.contains(GepNoWrapFlags::NUSW) {
-            emit("NUSW")?;
+            flags.remove(GepNoWrapFlags::NUSW);
         }
-        if flags.contains(GepNoWrapFlags::NUW) {
-            emit("NUW")?;
-        }
+
+        write!(f, "<")?;
+        bitflags::parser::to_writer(&flags, &mut *f)?;
         write!(f, ">")
     }
 }
@@ -580,19 +572,31 @@ mod tests {
     fn test_gep_no_wrap_flags_attr_parse_invalid() {
         let ctx = &mut Context::default();
         let input = "<INVALIDFLAG>";
-        match parse_from_str(GepNoWrapFlagsAttr::parser(()), ctx, input) {
-            Ok(parsed) => {
-                panic!("Expected error, but got: {}", parsed);
-            }
-            Err(e) => {
-                expect![[r#"
-                    Compilation error: invalid input program.
-                    Parse error at line: 1, column: 1
-                    Error parsing GEP no-wrap flags: unrecognized named flag `INVALIDFLAG`
-                "#]]
-                .assert_eq(&e.to_string());
-            }
-        }
+
+        let err = parse_from_str(GepNoWrapFlagsAttr::parser(()), ctx, input)
+            .expect_err("invalid GEP no-wrap flag must fail to parse");
+        let parse_errors = err
+            .err
+            .downcast_ref::<pliron::combine::easy::Errors<
+                char,
+                char,
+                pliron::combine::stream::position::SourcePosition,
+            >>()
+            .expect("expected combine parser errors");
+
+        let parse_err = parse_errors
+            .errors
+            .iter()
+            .find_map(|err| match err {
+                pliron::combine::easy::Error::Other(err) => {
+                    err.downcast_ref::<GepNoWrapFlagParseErr>()
+                }
+                _ => None,
+            })
+            .expect("expected GepNoWrapFlagParseErr");
+
+        expect!["Error parsing GEP no-wrap flags: unrecognized named flag `INVALIDFLAG`"]
+            .assert_eq(&parse_err.to_string());
     }
 
     fn assert_attr_roundtrips<A>(ctx: &mut Context, attr: A)

--- a/pliron-llvm/src/from_llvm_ir.rs
+++ b/pliron-llvm/src/from_llvm_ir.rs
@@ -60,16 +60,17 @@ use crate::{
         llvm_get_block_address_basic_block, llvm_get_block_address_function,
         llvm_get_called_function_type, llvm_get_called_value, llvm_get_cmpxchg_failure_ordering,
         llvm_get_cmpxchg_success_ordering, llvm_get_const_opcode, llvm_get_element_type,
-        llvm_get_fast_math_flags, llvm_get_fcmp_predicate, llvm_get_gep_source_element_type,
-        llvm_get_icmp_predicate, llvm_get_indices, llvm_get_initializer,
-        llvm_get_inline_asm_asm_string, llvm_get_inline_asm_constraint_string,
-        llvm_get_instruction_opcode, llvm_get_instruction_parent, llvm_get_int_type_width,
-        llvm_get_linkage, llvm_get_mask_value, llvm_get_module_identifier, llvm_get_nneg,
-        llvm_get_nsw, llvm_get_num_arg_operands, llvm_get_num_mask_elements, llvm_get_num_operands,
-        llvm_get_nuw, llvm_get_operand, llvm_get_ordering, llvm_get_param_types,
-        llvm_get_pointer_address_space, llvm_get_return_type, llvm_get_struct_element_types,
-        llvm_get_struct_name, llvm_get_switch_case_value, llvm_get_type_kind, llvm_get_value_kind,
-        llvm_get_value_name, llvm_get_vector_size, llvm_global_get_value_type,
+        llvm_get_fast_math_flags, llvm_get_fcmp_predicate, llvm_get_gep_no_wrap_flags,
+        llvm_get_gep_source_element_type, llvm_get_icmp_predicate, llvm_get_indices,
+        llvm_get_initializer, llvm_get_inline_asm_asm_string,
+        llvm_get_inline_asm_constraint_string, llvm_get_instruction_opcode,
+        llvm_get_instruction_parent, llvm_get_int_type_width, llvm_get_linkage,
+        llvm_get_mask_value, llvm_get_module_identifier, llvm_get_nneg, llvm_get_nsw,
+        llvm_get_num_arg_operands, llvm_get_num_mask_elements, llvm_get_num_operands, llvm_get_nuw,
+        llvm_get_operand, llvm_get_ordering, llvm_get_param_types, llvm_get_pointer_address_space,
+        llvm_get_return_type, llvm_get_struct_element_types, llvm_get_struct_name,
+        llvm_get_switch_case_value, llvm_get_type_kind, llvm_get_value_kind, llvm_get_value_name,
+        llvm_get_vector_size, llvm_global_get_value_type,
         llvm_instruction_get_all_metadata_other_than_debug_loc, llvm_is_a, llvm_is_declaration,
         llvm_is_function_type_var_arg, llvm_is_opaque_struct, llvm_is_packed_struct,
         llvm_lookup_intrinsic_id, llvm_print_value_to_string, llvm_type_of,
@@ -746,7 +747,13 @@ fn process_constant(ctx: &mut Context, cctx: &mut ConversionContext, val: LLVMVa
                     }
                     let src_elm_type =
                         convert_type(ctx, cctx, llvm_get_gep_source_element_type(val))?;
-                    let gep_op = GetElementPtrOp::new(ctx, m_base, indices, src_elm_type);
+                    let gep_op = GetElementPtrOp::new_with_no_wrap_flags(
+                        ctx,
+                        m_base,
+                        indices,
+                        src_elm_type,
+                        llvm_get_gep_no_wrap_flags(val),
+                    );
                     insert_const_inst(ctx, cctx, gep_op.get_operation());
                     cctx.value_map.insert(val, gep_op.get_result(ctx));
                 }
@@ -1353,7 +1360,14 @@ fn convert_instruction(
                 })
                 .collect::<Vec<_>>();
             let src_elm_type = convert_type(ctx, cctx, llvm_get_gep_source_element_type(inst))?;
-            Ok(GetElementPtrOp::new(ctx, *base, indices, src_elm_type).get_operation())
+            Ok(GetElementPtrOp::new_with_no_wrap_flags(
+                ctx,
+                *base,
+                indices,
+                src_elm_type,
+                llvm_get_gep_no_wrap_flags(inst),
+            )
+            .get_operation())
         }
         LLVMOpcode::LLVMICmp => {
             let pred = convert_ipredicate(llvm_get_icmp_predicate(inst));

--- a/pliron-llvm/src/llvm_sys/core.rs
+++ b/pliron-llvm/src/llvm_sys/core.rs
@@ -12,8 +12,9 @@ use std::{
 use llvm_sys::{
     LLVMAtomicOrdering, LLVMAtomicRMWBinOp, LLVMFastMathAllowContract, LLVMFastMathAllowReassoc,
     LLVMFastMathAllowReciprocal, LLVMFastMathApproxFunc, LLVMFastMathFlags, LLVMFastMathNoInfs,
-    LLVMFastMathNoNaNs, LLVMFastMathNoSignedZeros, LLVMFastMathNone, LLVMInlineAsmDialect,
-    LLVMIntPredicate, LLVMLinkage, LLVMOpcode, LLVMRealPredicate, LLVMTypeKind, LLVMValueKind,
+    LLVMFastMathNoNaNs, LLVMFastMathNoSignedZeros, LLVMFastMathNone, LLVMGEPFlagInBounds,
+    LLVMGEPFlagNUSW, LLVMGEPFlagNUW, LLVMGEPNoWrapFlags, LLVMInlineAsmDialect, LLVMIntPredicate,
+    LLVMLinkage, LLVMOpcode, LLVMRealPredicate, LLVMTypeKind, LLVMValueKind,
     analysis::LLVMVerifyModule,
     bit_writer::LLVMWriteBitcodeToFile,
     core::{
@@ -26,32 +27,32 @@ use llvm_sys::{
         LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFMul,
         LLVMBuildFNeg, LLVMBuildFPExt, LLVMBuildFPToSI, LLVMBuildFPToUI, LLVMBuildFPTrunc,
         LLVMBuildFRem, LLVMBuildFSub, LLVMBuildFenceSyncScope, LLVMBuildFreeze, LLVMBuildGEP2,
-        LLVMBuildICmp, LLVMBuildIndirectBr, LLVMBuildInsertElement, LLVMBuildInsertValue,
-        LLVMBuildIntToPtr, LLVMBuildLShr, LLVMBuildLoad2, LLVMBuildMul, LLVMBuildOr, LLVMBuildPhi,
-        LLVMBuildPtrToInt, LLVMBuildRet, LLVMBuildRetVoid, LLVMBuildSDiv, LLVMBuildSExt,
-        LLVMBuildSIToFP, LLVMBuildSRem, LLVMBuildSelect, LLVMBuildShl, LLVMBuildShuffleVector,
-        LLVMBuildStore, LLVMBuildSub, LLVMBuildSwitch, LLVMBuildTrunc, LLVMBuildUDiv,
-        LLVMBuildUIToFP, LLVMBuildURem, LLVMBuildUnreachable, LLVMBuildVAArg, LLVMBuildXor,
-        LLVMBuildZExt, LLVMCanValueUseFastMathFlags, LLVMClearInsertionPosition, LLVMConstInt,
-        LLVMConstIntGetZExtValue, LLVMConstNull, LLVMConstReal, LLVMConstRealGetDouble,
-        LLVMConstStringInContext2, LLVMConstVector, LLVMContextCreate, LLVMContextDispose,
-        LLVMCountIncoming, LLVMCountParamTypes, LLVMCountParams, LLVMCountStructElementTypes,
-        LLVMCreateBuilderInContext, LLVMCreateMemoryBufferWithContentsOfFile,
-        LLVMCreateMemoryBufferWithMemoryRangeCopy, LLVMDeleteFunction, LLVMDeleteGlobal,
-        LLVMDisposeMemoryBuffer, LLVMDisposeMessage, LLVMDisposeModule,
-        LLVMDisposeValueMetadataEntries, LLVMDoubleTypeInContext, LLVMDumpModule, LLVMDumpType,
-        LLVMDumpValue, LLVMFloatTypeInContext, LLVMFunctionType, LLVMGetAggregateElement,
-        LLVMGetAlignment, LLVMGetAllocatedType, LLVMGetArrayLength2, LLVMGetAsString,
-        LLVMGetAtomicRMWBinOp, LLVMGetAtomicSyncScopeID, LLVMGetBasicBlockName,
-        LLVMGetBasicBlockParent, LLVMGetBasicBlockTerminator, LLVMGetBlockAddressBasicBlock,
-        LLVMGetBlockAddressFunction, LLVMGetCalledFunctionType, LLVMGetCalledValue,
-        LLVMGetCmpXchgFailureOrdering, LLVMGetCmpXchgSuccessOrdering, LLVMGetConstOpcode,
-        LLVMGetDataLayoutStr, LLVMGetElementType, LLVMGetFCmpPredicate, LLVMGetFastMathFlags,
-        LLVMGetFirstBasicBlock, LLVMGetFirstFunction, LLVMGetFirstGlobal, LLVMGetFirstInstruction,
-        LLVMGetFirstNamedMetadata, LLVMGetFirstParam, LLVMGetGEPSourceElementType,
-        LLVMGetICmpPredicate, LLVMGetIncomingBlock, LLVMGetIncomingValue, LLVMGetIndices,
-        LLVMGetInitializer, LLVMGetInlineAsm, LLVMGetInlineAsmAsmString,
-        LLVMGetInlineAsmConstraintString, LLVMGetInlineAsmFunctionType,
+        LLVMBuildGEPWithNoWrapFlags, LLVMBuildICmp, LLVMBuildIndirectBr, LLVMBuildInsertElement,
+        LLVMBuildInsertValue, LLVMBuildIntToPtr, LLVMBuildLShr, LLVMBuildLoad2, LLVMBuildMul,
+        LLVMBuildOr, LLVMBuildPhi, LLVMBuildPtrToInt, LLVMBuildRet, LLVMBuildRetVoid,
+        LLVMBuildSDiv, LLVMBuildSExt, LLVMBuildSIToFP, LLVMBuildSRem, LLVMBuildSelect,
+        LLVMBuildShl, LLVMBuildShuffleVector, LLVMBuildStore, LLVMBuildSub, LLVMBuildSwitch,
+        LLVMBuildTrunc, LLVMBuildUDiv, LLVMBuildUIToFP, LLVMBuildURem, LLVMBuildUnreachable,
+        LLVMBuildVAArg, LLVMBuildXor, LLVMBuildZExt, LLVMCanValueUseFastMathFlags,
+        LLVMClearInsertionPosition, LLVMConstInt, LLVMConstIntGetZExtValue, LLVMConstNull,
+        LLVMConstReal, LLVMConstRealGetDouble, LLVMConstStringInContext2, LLVMConstVector,
+        LLVMContextCreate, LLVMContextDispose, LLVMCountIncoming, LLVMCountParamTypes,
+        LLVMCountParams, LLVMCountStructElementTypes, LLVMCreateBuilderInContext,
+        LLVMCreateMemoryBufferWithContentsOfFile, LLVMCreateMemoryBufferWithMemoryRangeCopy,
+        LLVMDeleteFunction, LLVMDeleteGlobal, LLVMDisposeMemoryBuffer, LLVMDisposeMessage,
+        LLVMDisposeModule, LLVMDisposeValueMetadataEntries, LLVMDoubleTypeInContext,
+        LLVMDumpModule, LLVMDumpType, LLVMDumpValue, LLVMFloatTypeInContext, LLVMFunctionType,
+        LLVMGEPGetNoWrapFlags, LLVMGetAggregateElement, LLVMGetAlignment, LLVMGetAllocatedType,
+        LLVMGetArrayLength2, LLVMGetAsString, LLVMGetAtomicRMWBinOp, LLVMGetAtomicSyncScopeID,
+        LLVMGetBasicBlockName, LLVMGetBasicBlockParent, LLVMGetBasicBlockTerminator,
+        LLVMGetBlockAddressBasicBlock, LLVMGetBlockAddressFunction, LLVMGetCalledFunctionType,
+        LLVMGetCalledValue, LLVMGetCmpXchgFailureOrdering, LLVMGetCmpXchgSuccessOrdering,
+        LLVMGetConstOpcode, LLVMGetDataLayoutStr, LLVMGetElementType, LLVMGetFCmpPredicate,
+        LLVMGetFastMathFlags, LLVMGetFirstBasicBlock, LLVMGetFirstFunction, LLVMGetFirstGlobal,
+        LLVMGetFirstInstruction, LLVMGetFirstNamedMetadata, LLVMGetFirstParam,
+        LLVMGetGEPSourceElementType, LLVMGetICmpPredicate, LLVMGetIncomingBlock,
+        LLVMGetIncomingValue, LLVMGetIndices, LLVMGetInitializer, LLVMGetInlineAsm,
+        LLVMGetInlineAsmAsmString, LLVMGetInlineAsmConstraintString, LLVMGetInlineAsmFunctionType,
         LLVMGetInlineAsmHasSideEffects, LLVMGetInsertBlock, LLVMGetInstructionOpcode,
         LLVMGetInstructionParent, LLVMGetIntTypeWidth, LLVMGetIntrinsicDeclaration,
         LLVMGetLastFunction, LLVMGetLastGlobal, LLVMGetLinkage, LLVMGetMDKindIDInContext,
@@ -99,7 +100,7 @@ use crate::llvm_sys::{
     ToBool, c_array_to_vec, cstr_to_string, sized_cstr_to_string, to_c_str, uninitialized_vec,
 };
 
-use crate::attributes::FastmathFlags;
+use crate::attributes::{FastmathFlags, GepNoWrapFlags};
 
 /// Opaque wrapper around LLVMValueRef to hide the raw pointer
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
@@ -286,6 +287,39 @@ impl From<FastmathFlags> for LLVMFastMathFlags {
         }
         if flags.contains(FastmathFlags::REASSOC) {
             result |= LLVMFastMathAllowReassoc;
+        }
+        result
+    }
+}
+
+impl From<LLVMGEPNoWrapFlags> for GepNoWrapFlags {
+    fn from(flags: LLVMGEPNoWrapFlags) -> Self {
+        let mut result = GepNoWrapFlags::empty();
+        if flags & LLVMGEPFlagInBounds != 0 {
+            result |= GepNoWrapFlags::INBOUNDS;
+        }
+        if flags & LLVMGEPFlagNUSW != 0 {
+            result |= GepNoWrapFlags::NUSW;
+        }
+        if flags & LLVMGEPFlagNUW != 0 {
+            result |= GepNoWrapFlags::NUW;
+        }
+        result.normalized()
+    }
+}
+
+impl From<GepNoWrapFlags> for LLVMGEPNoWrapFlags {
+    fn from(flags: GepNoWrapFlags) -> Self {
+        let flags = flags.normalized();
+        let mut result = 0;
+        if flags.contains(GepNoWrapFlags::INBOUNDS) {
+            result |= LLVMGEPFlagInBounds;
+        }
+        if flags.contains(GepNoWrapFlags::NUSW) {
+            result |= LLVMGEPFlagNUSW;
+        }
+        if flags.contains(GepNoWrapFlags::NUW) {
+            result |= LLVMGEPFlagNUW;
         }
         result
     }
@@ -2025,6 +2059,35 @@ pub fn llvm_build_gep2(
     }
 }
 
+/// LLVMBuildGEPWithNoWrapFlags
+pub fn llvm_build_gep_with_no_wrap_flags(
+    builder: &LLVMBuilder,
+    ty: LLVMType,
+    ptr: LLVMValue,
+    indices: &[LLVMValue],
+    name: &str,
+    flags: GepNoWrapFlags,
+) -> LLVMValue {
+    assert!(llvm_get_insert_block(builder).is_some());
+    assert!(
+        llvm_get_type_kind(llvm_get_scalar_type(llvm_type_of(ptr)))
+            == LLVMTypeKind::LLVMPointerTypeKind
+    );
+    let mut indices: Vec<_> = indices.iter().cloned().map(Into::into).collect();
+    unsafe {
+        LLVMBuildGEPWithNoWrapFlags(
+            builder.inner_ref(),
+            ty.into(),
+            ptr.into(),
+            indices.as_mut_ptr(),
+            indices.len().try_into().unwrap(),
+            to_c_str(name).as_ptr(),
+            flags.into(),
+        )
+        .into()
+    }
+}
+
 /// LLVMBuildInsertElement
 pub fn llvm_build_insert_element(
     builder: &LLVMBuilder,
@@ -2730,6 +2793,16 @@ pub fn llvm_get_gep_source_element_type(gep: LLVMValue) -> LLVMType {
                 && llvm_get_const_opcode(gep) == LLVMOpcode::LLVMGetElementPtr)
     );
     unsafe { LLVMGetGEPSourceElementType(gep.into()).into() }
+}
+
+/// LLVMGEPGetNoWrapFlags
+pub fn llvm_get_gep_no_wrap_flags(gep: LLVMValue) -> GepNoWrapFlags {
+    assert!(
+        llvm_is_a::get_element_ptr_inst(gep)
+            || (llvm_is_a::constant_expr(gep)
+                && llvm_get_const_opcode(gep) == LLVMOpcode::LLVMGetElementPtr)
+    );
+    unsafe { LLVMGEPGetNoWrapFlags(gep.into()) }.into()
 }
 
 /// LLVMGetNumIndices

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -91,7 +91,9 @@ use pliron::derive::{op_interface_impl, pliron_op};
 use thiserror::Error;
 
 use super::{
-    attributes::{GepIndexAttr, GepIndicesAttr, ICmpPredicateAttr},
+    attributes::{
+        GepIndexAttr, GepIndicesAttr, GepNoWrapFlags, GepNoWrapFlagsAttr, ICmpPredicateAttr,
+    },
     types::PointerType,
 };
 
@@ -1477,11 +1479,11 @@ pub enum GetElementPtrOpErr {
 /// | `res` | LLVM pointer type |
 #[pliron_op(
     name = "llvm.gep",
-    format = "`<` attr($gep_src_elem_type, $TypeAttr) `>` ` (` operands(CharSpace(`,`)) `)` attr($gep_indices, $GepIndicesAttr) ` : ` type($0)",
+    format = "`<` attr($gep_src_elem_type, $TypeAttr) `>` ` (` operands(CharSpace(`,`)) `)` opt_attr($gep_no_wrap_flags, $GepNoWrapFlagsAttr) attr($gep_indices, $GepIndicesAttr) ` : ` type($0)",
     interfaces = [OneResultInterface],
     operands = (src_ptr, dynamic_indices),
     results = (_: PointerType),
-    attributes = (gep_src_elem_type: TypeAttr, gep_indices: GepIndicesAttr)
+    attributes = (gep_src_elem_type: TypeAttr, gep_indices: GepIndicesAttr, gep_no_wrap_flags: GepNoWrapFlagsAttr)
 )]
 pub struct GetElementPtrOp;
 
@@ -1524,6 +1526,17 @@ impl GetElementPtrOp {
         indices: Vec<GepIndex>,
         src_elem_type: TypeHandle,
     ) -> Self {
+        Self::new_with_no_wrap_flags(ctx, base, indices, src_elem_type, GepNoWrapFlags::empty())
+    }
+
+    /// Create a new [GetElementPtrOp] with LLVM no-wrap flags.
+    pub fn new_with_no_wrap_flags(
+        ctx: &mut Context,
+        base: Value,
+        indices: Vec<GepIndex>,
+        src_elem_type: TypeHandle,
+        no_wrap_flags: GepNoWrapFlags,
+    ) -> Self {
         use pliron::r#type::Typed;
 
         // A GEP result inherits the address space of its base pointer.
@@ -1560,7 +1573,16 @@ impl GetElementPtrOp {
 
         op.set_attr_gep_indices(ctx, GepIndicesAttr(attr));
         op.set_attr_gep_src_elem_type(ctx, src_elem_type);
+        if !no_wrap_flags.is_empty() {
+            op.set_attr_gep_no_wrap_flags(ctx, no_wrap_flags.into());
+        }
         op
+    }
+
+    /// Get the GEP no-wrap flags.
+    pub fn no_wrap_flags(&self, ctx: &Context) -> GepNoWrapFlags {
+        self.get_attr_gep_no_wrap_flags(ctx)
+            .map_or(GepNoWrapFlags::empty(), |attr| attr.0.normalized())
     }
 
     /// Get the source pointer's element type.

--- a/pliron-llvm/src/to_llvm_ir.rs
+++ b/pliron-llvm/src/to_llvm_ir.rs
@@ -60,11 +60,11 @@ use crate::{
         llvm_build_cond_br, llvm_build_extract_element, llvm_build_extract_value, llvm_build_fadd,
         llvm_build_fcmp, llvm_build_fdiv, llvm_build_fence, llvm_build_fmul, llvm_build_fneg,
         llvm_build_fpext, llvm_build_fptosi, llvm_build_fptoui, llvm_build_fptrunc,
-        llvm_build_freeze, llvm_build_frem, llvm_build_fsub, llvm_build_gep2, llvm_build_icmp,
-        llvm_build_indirect_br, llvm_build_insert_element, llvm_build_insert_value,
-        llvm_build_int_to_ptr, llvm_build_load2, llvm_build_lshr, llvm_build_mul, llvm_build_or,
-        llvm_build_phi, llvm_build_ptr_to_int, llvm_build_ret, llvm_build_ret_void,
-        llvm_build_sdiv, llvm_build_select, llvm_build_sext, llvm_build_shl,
+        llvm_build_freeze, llvm_build_frem, llvm_build_fsub, llvm_build_gep_with_no_wrap_flags,
+        llvm_build_icmp, llvm_build_indirect_br, llvm_build_insert_element,
+        llvm_build_insert_value, llvm_build_int_to_ptr, llvm_build_load2, llvm_build_lshr,
+        llvm_build_mul, llvm_build_or, llvm_build_phi, llvm_build_ptr_to_int, llvm_build_ret,
+        llvm_build_ret_void, llvm_build_sdiv, llvm_build_select, llvm_build_sext, llvm_build_shl,
         llvm_build_shuffle_vector, llvm_build_sitofp, llvm_build_srem, llvm_build_store,
         llvm_build_sub, llvm_build_switch, llvm_build_trunc, llvm_build_udiv, llvm_build_uitofp,
         llvm_build_unreachable, llvm_build_urem, llvm_build_va_arg, llvm_build_xor,
@@ -1509,12 +1509,13 @@ impl ToLLVMValue for GetElementPtrOp {
         let base = convert_value_operand(cctx, ctx, &self.get_operand_src_ptr(ctx))?;
 
         let src_elem_type = convert_type(ctx, llvm_ctx, cctx, self.src_elem_type(ctx))?;
-        let gep_op = llvm_build_gep2(
+        let gep_op = llvm_build_gep_with_no_wrap_flags(
             &cctx.builder,
             src_elem_type,
             base,
             &indices,
             self.get_result(ctx).unique_name(ctx).as_ref(),
+            self.no_wrap_flags(ctx),
         );
         Ok(gep_op)
     }

--- a/pliron-llvm/tests/ir_expect.rs
+++ b/pliron-llvm/tests/ir_expect.rs
@@ -220,6 +220,42 @@ fn llvm_ir_select_without_fastmath_flags_omits_attr() -> Result<()> {
     Ok(())
 }
 
+/// GEP no-wrap flags must survive LLVM -> pliron -> LLVM conversion.
+#[test]
+fn llvm_ir_gep_no_wrap_flags_roundtrip() -> Result<()> {
+    init_env_logger_for_tests!();
+    let input = r#"
+        define ptr @gep_flags(ptr %p, i64 %i) {
+        entry:
+          %plain = getelementptr i8, ptr %p, i64 %i
+          %nusw = getelementptr nusw i8, ptr %p, i64 %i
+          %nuw = getelementptr nuw i8, ptr %p, i64 %i
+          %inbounds = getelementptr inbounds i8, ptr %p, i64 %i
+          %both = getelementptr inbounds nuw i8, ptr %p, i64 %i
+          ret ptr %both
+        }
+    "#;
+
+    let llvm_ctx = LLVMContext::default();
+    let ctx = &mut Context::new();
+    let module_op = common::parse_llvm_ir_verify(ctx, &llvm_ctx, input, "gep_flags")?;
+
+    let pliron_text = module_op.disp(ctx).to_string();
+    assert!(pliron_text.contains("<NUSW>"));
+    assert!(pliron_text.contains("<NUW>"));
+    assert!(pliron_text.contains("<INBOUNDS>"));
+    assert!(pliron_text.contains("<INBOUNDS | NUW>"));
+
+    let out_llvm_ctx = LLVMContext::default();
+    let out_mod = to_llvm_ir::convert_module(ctx, &out_llvm_ctx, module_op)?;
+    let out = out_mod.to_string();
+    assert!(out.contains("getelementptr nusw i8"));
+    assert!(out.contains("getelementptr nuw i8"));
+    assert!(out.contains("getelementptr inbounds i8"));
+    assert!(out.contains("getelementptr inbounds nuw i8"));
+    Ok(())
+}
+
 /// Combinations of `struct` types
 #[test]
 fn llvm_ir_struct_combinations_roundtrip() -> Result<()> {

--- a/pliron-llvm/tests/ir_expect.rs
+++ b/pliron-llvm/tests/ir_expect.rs
@@ -240,19 +240,48 @@ fn llvm_ir_gep_no_wrap_flags_roundtrip() -> Result<()> {
     let ctx = &mut Context::new();
     let module_op = common::parse_llvm_ir_verify(ctx, &llvm_ctx, input, "gep_flags")?;
 
-    let pliron_text = module_op.disp(ctx).to_string();
-    assert!(pliron_text.contains("<NUSW>"));
-    assert!(pliron_text.contains("<NUW>"));
-    assert!(pliron_text.contains("<INBOUNDS>"));
-    assert!(pliron_text.contains("<INBOUNDS | NUW>"));
+    let pliron_text = module_op
+        .disp(ctx)
+        .to_string()
+        .lines()
+        .map(str::trim_end)
+        .collect::<Vec<_>>()
+        .join("\n");
+    expect![[r#"
+        builtin.module @gep_flags
+        {
+          ^block1v1():
+            llvm.func @gep_flags: llvm.func <llvm.ptr (0)(llvm.ptr (0), builtin.integer i64) variadic = false>
+              [llvm_function_linkage: llvm.linkage ExternalLinkage]
+            {
+              ^entry_block2v1(v0: llvm.ptr (0), v1: builtin.integer i64):
+                plain_v2 = llvm.gep <builtin.integer i8> (v0, v1)[OperandIdx(1)] : llvm.ptr (0) !0;
+                nusw_v3 = llvm.gep <builtin.integer i8> (v0, v1)<NUSW>[OperandIdx(1)] : llvm.ptr (0) !1;
+                nuw_v4 = llvm.gep <builtin.integer i8> (v0, v1)<NUW>[OperandIdx(1)] : llvm.ptr (0) !2;
+                inbounds_v5 = llvm.gep <builtin.integer i8> (v0, v1)<INBOUNDS>[OperandIdx(1)] : llvm.ptr (0) !3;
+                both_v6 = llvm.gep <builtin.integer i8> (v0, v1)<INBOUNDS | NUW>[OperandIdx(1)] : llvm.ptr (0) !4;
+                llvm.return both_v6
+            }
+        }"#]].assert_eq(&pliron_text);
 
     let out_llvm_ctx = LLVMContext::default();
     let out_mod = to_llvm_ir::convert_module(ctx, &out_llvm_ctx, module_op)?;
     let out = out_mod.to_string();
-    assert!(out.contains("getelementptr nusw i8"));
-    assert!(out.contains("getelementptr nuw i8"));
-    assert!(out.contains("getelementptr inbounds i8"));
-    assert!(out.contains("getelementptr inbounds nuw i8"));
+    expect![[r#"
+        ; ModuleID = 'gep_flags'
+        source_filename = "gep_flags"
+
+        define ptr @gep_flags(ptr %0, i64 %1) {
+        entry_block2v1:
+          %plain_v2 = getelementptr i8, ptr %0, i64 %1
+          %nusw_v3 = getelementptr nusw i8, ptr %0, i64 %1
+          %nuw_v4 = getelementptr nuw i8, ptr %0, i64 %1
+          %inbounds_v5 = getelementptr inbounds i8, ptr %0, i64 %1
+          %both_v6 = getelementptr inbounds nuw i8, ptr %0, i64 %1
+          ret ptr %both_v6
+        }
+    "#]]
+    .assert_eq(&out);
     Ok(())
 }
 

--- a/pliron-llvm/tests/ir_expect.rs
+++ b/pliron-llvm/tests/ir_expect.rs
@@ -18,7 +18,6 @@ use pliron_llvm::{
     from_llvm_ir,
     llvm_sys::core::LLVMContext,
     ops::{ConstantOpVerifyErr, SelectOpVerifyErr},
-    to_llvm_ir,
 };
 
 mod common;
@@ -252,19 +251,12 @@ fn llvm_ir_gep_no_wrap_flags_roundtrip() -> Result<()> {
     let ctx = &mut Context::new();
     let module_op = common::parse_llvm_ir_verify(ctx, &llvm_ctx, input, "gep_flags")?;
 
-    let pliron_text = module_op
-        .disp(ctx)
-        .to_string()
-        .lines()
-        .map(str::trim_end)
-        .collect::<Vec<_>>()
-        .join("\n");
     expect![[r#"
-        builtin.module @gep_flags
+        builtin.module @gep_flags 
         {
           ^block1v1():
             llvm.func @gep_flags: llvm.func <llvm.ptr (0)(llvm.ptr (0), builtin.integer i64) variadic = false>
-              [llvm_function_linkage: llvm.linkage ExternalLinkage]
+              [llvm_function_linkage: llvm.linkage ExternalLinkage] 
             {
               ^entry_block2v1(v0: llvm.ptr (0), v1: builtin.integer i64):
                 plain_v2 = llvm.gep <builtin.integer i8> (v0, v1)[OperandIdx(1)] : llvm.ptr (0) !0;
@@ -274,11 +266,10 @@ fn llvm_ir_gep_no_wrap_flags_roundtrip() -> Result<()> {
                 both_v6 = llvm.gep <builtin.integer i8> (v0, v1)<INBOUNDS | NUW>[OperandIdx(1)] : llvm.ptr (0) !4;
                 llvm.return both_v6
             }
-        }"#]].assert_eq(&pliron_text);
+        }"#]].assert_eq(&module_op.disp(ctx).to_string());
 
     let out_llvm_ctx = LLVMContext::default();
-    let out_mod = to_llvm_ir::convert_module(ctx, &out_llvm_ctx, module_op)?;
-    let out = out_mod.to_string();
+    let out_mod = common::to_llvm_ir_verify(ctx, &out_llvm_ctx, module_op)?;
     expect![[r#"
         ; ModuleID = 'gep_flags'
         source_filename = "gep_flags"
@@ -293,7 +284,7 @@ fn llvm_ir_gep_no_wrap_flags_roundtrip() -> Result<()> {
           ret ptr %both_v6
         }
     "#]]
-    .assert_eq(&out);
+    .assert_eq(&out_mod.to_string());
     Ok(())
 }
 

--- a/pliron-llvm/tests/metadata.rs
+++ b/pliron-llvm/tests/metadata.rs
@@ -116,10 +116,10 @@ fn metadata_from_llvm_ir() -> Result<()> {
                 llvm.br ^loop_block3v1(v3)
 
               ^loop_block3v1(v4: builtin.integer i64):
-                sp_v5 = llvm.gep <builtin.integer i32> (v1, v4)[OperandIdx(1)] : llvm.ptr (0) !0;
+                sp_v5 = llvm.gep <builtin.integer i32> (v1, v4)<INBOUNDS>[OperandIdx(1)] : llvm.ptr (0) !0;
                 v_v6 = llvm.load sp_v5 [align : 4] : builtin.integer i32 !1;
                 inc_v8 = llvm.add v_v6, v7 <{nsw=true,nuw=false}>: builtin.integer i32 !2;
-                dp_v9 = llvm.gep <builtin.integer i32> (v0, v4)[OperandIdx(1)] : llvm.ptr (0) !3;
+                dp_v9 = llvm.gep <builtin.integer i32> (v0, v4)<INBOUNDS>[OperandIdx(1)] : llvm.ptr (0) !3;
                 llvm.store *dp_v9 <- inc_v8 [align : 4] !4;
                 i_next_v11 = llvm.add v4, v10 <{nsw=true,nuw=true}>: builtin.integer i64 !5;
                 done_v13 = llvm.icmp i_next_v11 <EQ> v12 : builtin.integer i1 !6;
@@ -226,10 +226,10 @@ fn metadata_to_llvm_ir() -> Result<()> {
 
         loop_block3v1:                                    ; preds = %loop_block3v1, %entry_block2v1
           %v4 = phi i64 [ 0, %entry_block2v1 ], [ %i_next_v11, %loop_block3v1 ]
-          %sp_v5 = getelementptr i32, ptr %1, i64 %v4
+          %sp_v5 = getelementptr inbounds i32, ptr %1, i64 %v4
           %v_v6 = load i32, ptr %sp_v5, align 4, !tbaa !3, !alias.scope !7, !noalias !10
           %inc_v8 = add i32 %v_v6, 1
-          %dp_v9 = getelementptr i32, ptr %0, i64 %v4
+          %dp_v9 = getelementptr inbounds i32, ptr %0, i64 %v4
           store i32 %inc_v8, ptr %dp_v9, align 4, !tbaa !3, !alias.scope !10, !noalias !7, !my.custom.kind !12
           %i_next_v11 = add i64 %v4, 1
           %done_v13 = icmp eq i64 %i_next_v11, 16


### PR DESCRIPTION
## Summary

Add support for preserving LLVM `getelementptr` no-wrap flags across LLVM IR ↔ Pliron conversion.

This adds support for:

* `inbounds`
* `nusw`
* `nuw`

and preserves LLVM's canonical semantics where `inbounds` implies `nusw`.

## Changes

* Add `GepNoWrapFlags` and `GepNoWrapFlagsAttr`.
* Add parsing and printing support for GEP no-wrap flags.
* Preserve no-wrap flags when importing LLVM GEP instructions.
* Preserve no-wrap flags when importing GEP constant expressions.
* Emit GEP no-wrap flags through LLVM 23's `LLVMBuildGEPWithNoWrapFlags`.
* Add wrappers for `LLVMGEPGetNoWrapFlags` and the LLVM GEP flag representation.
* Keep `GetElementPtrOp::new` backward compatible and add `new_with_no_wrap_flags`.
* Update existing metadata round-trip expectations to preserve `inbounds`.
* Add unit tests for flag parsing, printing, normalization, and invalid input.
* Add an LLVM IR round-trip test covering plain, `nusw`, `nuw`, `inbounds`, and `inbounds nuw` GEPs.

GEPs without no-wrap flags retain the existing representation and behavior.

## Testing

Validated locally against LLVM 23 / `llvm-sys` 231 with:

```text
./pre-ci.sh
```

This passes formatting, Clippy with warnings denied, the full workspace test suite, doctests, and documentation checks.

## Checklist

* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
* [x] A human is involved in writing this PR description and will handle review interactions, per our [AI tool policy](../CONTRIBUTING.md).
* [x] I understand every part of this change (including any AI-generated code) and can explain the reasoning behind it.
* [x] Intrusive / large changes were discussed on Discord before this PR.
* [x] `pre-ci.sh` passes locally.
