### PR TITLE
[pliron-llvm] Preserve volatile load/store across LLVM IR conversion

### DIFF
--- a/pliron-derive/src/derive_format.rs
+++ b/pliron-derive/src/derive_format.rs
@@ -1517,7 +1517,8 @@ impl ParsableBuilder<OpParserState> for DeriveOpParsable {
             if d.name == "opt_attr" {
                 Ok(quote! {
                     let #attr_name_ident = ::pliron::combine::parser::choice::optional
-                        (#delimited_labelled_parser).parse_stream(state_stream).into_result()?.0;
+                        (::pliron::combine::attempt(#delimited_labelled_parser))
+                        .parse_stream(state_stream).into_result()?.0;
                 })
             } else {
                 Ok(quote! {

--- a/pliron-llvm/src/from_llvm_ir.rs
+++ b/pliron-llvm/src/from_llvm_ir.rs
@@ -68,7 +68,7 @@ use crate::{
         llvm_get_operand, llvm_get_ordering, llvm_get_param_types, llvm_get_pointer_address_space,
         llvm_get_return_type, llvm_get_struct_element_types, llvm_get_struct_name,
         llvm_get_switch_case_value, llvm_get_type_kind, llvm_get_value_kind, llvm_get_value_name,
-        llvm_get_vector_size, llvm_global_get_value_type,
+        llvm_get_vector_size, llvm_get_volatile, llvm_global_get_value_type,
         llvm_instruction_get_all_metadata_other_than_debug_loc, llvm_is_a, llvm_is_declaration,
         llvm_is_function_type_var_arg, llvm_is_opaque_struct, llvm_is_packed_struct,
         llvm_lookup_intrinsic_id, llvm_print_type_to_string, llvm_print_value_to_string,
@@ -1455,8 +1455,12 @@ fn convert_instruction(
             let ptr = get_operand(opds, 0)?;
             let alignment = llvm_get_alignment(inst);
             let ordering = llvm_get_ordering(inst);
+            let is_volatile = llvm_get_volatile(inst);
             if matches!(ordering, LLVMAtomicOrdering::LLVMAtomicOrderingNotAtomic) {
                 let load_op = LoadOp::new(ctx, ptr, res_ty);
+                if is_volatile {
+                    load_op.set_volatile(ctx, true);
+                }
                 if alignment != 0 {
                     load_op.set_alignment(ctx, alignment);
                 }
@@ -1561,8 +1565,12 @@ fn convert_instruction(
             let (value_opd, ptr_opd) = (get_operand(opds, 0)?, get_operand(opds, 1)?);
             let alignment = llvm_get_alignment(inst);
             let ordering = llvm_get_ordering(inst);
+            let is_volatile = llvm_get_volatile(inst);
             if matches!(ordering, LLVMAtomicOrdering::LLVMAtomicOrderingNotAtomic) {
                 let store_op = StoreOp::new(ctx, value_opd, ptr_opd);
+                if is_volatile {
+                    store_op.set_volatile(ctx, true);
+                }
                 if alignment != 0 {
                     store_op.set_alignment(ctx, alignment);
                 }

--- a/pliron-llvm/src/from_llvm_ir.rs
+++ b/pliron-llvm/src/from_llvm_ir.rs
@@ -81,6 +81,7 @@ use crate::{
     op_interfaces::{
         AlignableOpInterface, BinArithOp, CastOpInterface, CastOpWithNNegInterface, FastMathFlags,
         FloatBinArithOpWithFastMathFlags, IntBinArithOpWithOverflowFlag, LlvmSymbolName,
+        VolatilityOpInterface,
     },
     ops::{
         AShrOp, AddOp, AddrSpaceCastOp, AddressOfOp, AllocaOp, AndOp, AtomicCmpxchgOp,

--- a/pliron-llvm/src/llvm_sys/core.rs
+++ b/pliron-llvm/src/llvm_sys/core.rs
@@ -69,7 +69,7 @@ use llvm_sys::{
         LLVMGetPreviousParam, LLVMGetReturnType, LLVMGetStructElementTypes, LLVMGetStructName,
         LLVMGetSwitchCaseValue, LLVMGetSyncScopeID, LLVMGetTarget, LLVMGetTypeKind, LLVMGetUndef,
         LLVMGetUndefMaskElem, LLVMGetValueKind, LLVMGetValueName2, LLVMGetVectorSize,
-        LLVMGlobalCopyAllMetadata, LLVMGlobalGetValueType, LLVMGlobalSetMetadata,
+        LLVMGetVolatile, LLVMGlobalCopyAllMetadata, LLVMGlobalGetValueType, LLVMGlobalSetMetadata,
         LLVMHalfTypeInContext, LLVMInstructionEraseFromParent,
         LLVMInstructionGetAllMetadataOtherThanDebugLoc, LLVMIntTypeInContext,
         LLVMIntrinsicIsOverloaded, LLVMIsAFunction, LLVMIsATerminatorInst, LLVMIsAUser,
@@ -80,9 +80,9 @@ use llvm_sys::{
         LLVMPrintModuleToString, LLVMPrintTypeToString, LLVMPrintValueToString,
         LLVMReplaceAllUsesWith, LLVMScalableVectorType, LLVMSetAlignment, LLVMSetAtomicSyncScopeID,
         LLVMSetDataLayout, LLVMSetFastMathFlags, LLVMSetInitializer, LLVMSetLinkage,
-        LLVMSetMetadata, LLVMSetNNeg, LLVMSetOrdering, LLVMSetTarget, LLVMStructCreateNamed,
-        LLVMStructSetBody, LLVMStructTypeInContext, LLVMTypeIsSized, LLVMTypeOf,
-        LLVMValueAsBasicBlock, LLVMValueAsMetadata, LLVMValueIsBasicBlock,
+        LLVMSetMetadata, LLVMSetNNeg, LLVMSetOrdering, LLVMSetTarget, LLVMSetVolatile,
+        LLVMStructCreateNamed, LLVMStructSetBody, LLVMStructTypeInContext, LLVMTypeIsSized,
+        LLVMTypeOf, LLVMValueAsBasicBlock, LLVMValueAsMetadata, LLVMValueIsBasicBlock,
         LLVMValueMetadataEntriesGetKind, LLVMValueMetadataEntriesGetMetadata, LLVMVectorType,
         LLVMVoidTypeInContext,
     },
@@ -1254,6 +1254,18 @@ pub fn llvm_set_alignment(val: LLVMValue, align: u32) {
             || llvm_is_a::store_inst(val)
     );
     unsafe { LLVMSetAlignment(val.into(), align) }
+}
+
+/// LLVMGetVolatile
+pub fn llvm_get_volatile(val: LLVMValue) -> bool {
+    assert!(llvm_is_a::load_inst(val) || llvm_is_a::store_inst(val));
+    unsafe { LLVMGetVolatile(val.into()).to_bool() }
+}
+
+/// LLVMSetVolatile
+pub fn llvm_set_volatile(val: LLVMValue, is_volatile: bool) {
+    assert!(llvm_is_a::load_inst(val) || llvm_is_a::store_inst(val));
+    unsafe { LLVMSetVolatile(val.into(), is_volatile.into()) }
 }
 
 /// LLVMGetNumMaskElements

--- a/pliron-llvm/src/op_interfaces.rs
+++ b/pliron-llvm/src/op_interfaces.rs
@@ -539,6 +539,47 @@ pub trait AlignableOpInterface {
     }
 }
 
+dict_key!(
+    /// Attribute key for volatile memory operations.
+    ATTR_KEY_LLVM_VOLATILE,
+    "llvm_volatile"
+);
+
+/// Ops that can be marked volatile.
+#[op_interface]
+pub trait VolatilityOpInterface {
+    /// Return whether this [Op] is volatile.
+    fn is_volatile(&self, ctx: &Context) -> bool
+    where
+        Self: Sized,
+    {
+        self.get_operation()
+            .deref(ctx)
+            .attributes
+            .get::<BoolAttr>(&ATTR_KEY_LLVM_VOLATILE)
+            .map(|attr| attr.clone().into())
+            .unwrap_or(false)
+    }
+
+    /// Set whether this [Op] is volatile.
+    fn set_volatile(&self, ctx: &Context, is_volatile: bool)
+    where
+        Self: Sized,
+    {
+        self.get_operation()
+            .deref_mut(ctx)
+            .attributes
+            .set(ATTR_KEY_LLVM_VOLATILE.clone(), BoolAttr::new(is_volatile));
+    }
+
+    fn verify(_op: &dyn Op, _ctx: &Context) -> Result<()>
+    where
+        Self: Sized,
+    {
+        Ok(())
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum ScalarOrVectorErr {
     #[error("{0} is not {1} or a vector of it")]

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -32,6 +32,7 @@ use pliron::{
     },
     common_traits::{Named, Verify},
     context::{Context, Ptr},
+    dict_key,
     graph::walkers::{self, IRNode, WALKCONFIG_PREORDER_FORWARD},
     identifier::Identifier,
     indented_block, input_err,
@@ -1642,6 +1643,12 @@ impl GetElementPtrOp {
     }
 }
 
+dict_key!(
+    /// Attribute key for volatile memory operations.
+    ATTR_KEY_LLVM_VOLATILE,
+    "llvm_volatile"
+);
+
 #[derive(Error, Debug)]
 pub enum LoadOpVerifyErr {
     #[error("Load operand must be a pointer")]
@@ -1661,7 +1668,7 @@ pub enum LoadOpVerifyErr {
 /// | `res` | sized LLVM type |
 #[pliron_op(
     name = "llvm.load",
-    format = "$0 ` ` opt_attr($llvm_alignment, $AlignmentAttr, label($align), delimiters(`[`, `]`)) ` : ` type($0)",
+    format = "opt_attr($llvm_volatile, $BoolAttr, label($volatile), delimiters(`[`, `] `)) $0 ` ` opt_attr($llvm_alignment, $AlignmentAttr, label($align), delimiters(`[`, `]`)) ` : ` type($0)",
     interfaces = [
         OneResultInterface,
         OneOpdInterface,
@@ -1685,6 +1692,24 @@ impl LoadOp {
             ),
         }
     }
+
+    /// Return whether this is a volatile load.
+    pub fn is_volatile(&self, ctx: &Context) -> bool {
+        self.get_operation()
+            .deref(ctx)
+            .attributes
+            .get::<BoolAttr>(&ATTR_KEY_LLVM_VOLATILE)
+            .map(|attr| attr.clone().into())
+            .unwrap_or(false)
+    }
+
+    /// Set whether this is a volatile load.
+    pub fn set_volatile(&self, ctx: &Context, is_volatile: bool) {
+        self.get_operation()
+            .deref_mut(ctx)
+            .attributes
+            .set(ATTR_KEY_LLVM_VOLATILE.clone(), BoolAttr::new(is_volatile));
+    }
 }
 
 #[derive(Error, Debug)]
@@ -1703,7 +1728,7 @@ pub enum StoreOpVerifyErr {
 /// | `value` | Sized type |
 #[pliron_op(
     name = "llvm.store",
-    format = "`*` $1 ` <- ` $0 ` ` opt_attr($llvm_alignment, $AlignmentAttr, label($align), delimiters(`[`, `]`))",
+    format = "opt_attr($llvm_volatile, $BoolAttr, label($volatile), delimiters(`[`, `] `)) `*` $1 ` <- ` $0 ` ` opt_attr($llvm_alignment, $AlignmentAttr, label($align), delimiters(`[`, `]`))",
     interfaces = [
         NResultsInterface<0>,
         AlignableOpInterface,
@@ -1726,6 +1751,24 @@ impl StoreOp {
                 0,
             ),
         }
+    }
+
+    /// Return whether this is a volatile store.
+    pub fn is_volatile(&self, ctx: &Context) -> bool {
+        self.get_operation()
+            .deref(ctx)
+            .attributes
+            .get::<BoolAttr>(&ATTR_KEY_LLVM_VOLATILE)
+            .map(|attr| attr.clone().into())
+            .unwrap_or(false)
+    }
+
+    /// Set whether this is a volatile store.
+    pub fn set_volatile(&self, ctx: &Context, is_volatile: bool) {
+        self.get_operation()
+            .deref_mut(ctx)
+            .attributes
+            .set(ATTR_KEY_LLVM_VOLATILE.clone(), BoolAttr::new(is_volatile));
     }
 }
 

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -1661,7 +1661,7 @@ pub enum LoadOpVerifyErr {
 /// | `res` | sized LLVM type |
 #[pliron_op(
     name = "llvm.load",
-    format = "opt_attr($llvm_volatile, $BoolAttr, label($volatile), delimiters(`[`, `] `)) $0 ` ` opt_attr($llvm_alignment, $AlignmentAttr, label($align), delimiters(`[`, `]`)) ` : ` type($0)",
+    format = "$0 ` ` opt_attr($llvm_volatile, $BoolAttr, label($volatile), delimiters(`[`, `]`)) opt_attr($llvm_alignment, $AlignmentAttr, label($align), delimiters(`[`, `]`)) ` : ` type($0)",
     interfaces = [
         OneResultInterface,
         OneOpdInterface,
@@ -1704,7 +1704,7 @@ pub enum StoreOpVerifyErr {
 /// | `value` | Sized type |
 #[pliron_op(
     name = "llvm.store",
-    format = "opt_attr($llvm_volatile, $BoolAttr, label($volatile), delimiters(`[`, `] `)) `*` $1 ` <- ` $0 ` ` opt_attr($llvm_alignment, $AlignmentAttr, label($align), delimiters(`[`, `]`))",
+    format = "`*` $1 ` <- ` $0 ` ` opt_attr($llvm_volatile, $BoolAttr, label($volatile), delimiters(`[`, `]`)) opt_attr($llvm_alignment, $AlignmentAttr, label($align), delimiters(`[`, `]`))",
     interfaces = [
         NResultsInterface<0>,
         AlignableOpInterface,

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -32,7 +32,6 @@ use pliron::{
     },
     common_traits::{Named, Verify},
     context::{Context, Ptr},
-    dict_key,
     graph::walkers::{self, IRNode, WALKCONFIG_PREORDER_FORWARD},
     identifier::Identifier,
     indented_block, input_err,
@@ -71,7 +70,7 @@ use crate::{
         FloatBinArithOp, FloatBinArithOpWithFastMathFlags, IntBinArithOp,
         IntBinArithOpWithOverflowFlag, IsDeclaration, LlvmSymbolName, NNegFlag, PointerTypeResult,
         ScalarOrVectorOpd, ScalarOrVectorOpdImpls, ScalarOrVectorRes, ScalarOrVectorResImpls,
-        SyncScopeInterface,
+        SyncScopeInterface, VolatilityOpInterface,
     },
     ops::{
         func_op_attr_names::ATTR_KEY_LLVM_FUNC_TYPE,
@@ -1643,12 +1642,6 @@ impl GetElementPtrOp {
     }
 }
 
-dict_key!(
-    /// Attribute key for volatile memory operations.
-    ATTR_KEY_LLVM_VOLATILE,
-    "llvm_volatile"
-);
-
 #[derive(Error, Debug)]
 pub enum LoadOpVerifyErr {
     #[error("Load operand must be a pointer")]
@@ -1673,6 +1666,7 @@ pub enum LoadOpVerifyErr {
         OneResultInterface,
         OneOpdInterface,
         AlignableOpInterface,
+        VolatilityOpInterface,
     ],
     operands = (address: PointerType),
     verifier = "succ"
@@ -1691,24 +1685,6 @@ impl LoadOp {
                 0,
             ),
         }
-    }
-
-    /// Return whether this is a volatile load.
-    pub fn is_volatile(&self, ctx: &Context) -> bool {
-        self.get_operation()
-            .deref(ctx)
-            .attributes
-            .get::<BoolAttr>(&ATTR_KEY_LLVM_VOLATILE)
-            .map(|attr| attr.clone().into())
-            .unwrap_or(false)
-    }
-
-    /// Set whether this is a volatile load.
-    pub fn set_volatile(&self, ctx: &Context, is_volatile: bool) {
-        self.get_operation()
-            .deref_mut(ctx)
-            .attributes
-            .set(ATTR_KEY_LLVM_VOLATILE.clone(), BoolAttr::new(is_volatile));
     }
 }
 
@@ -1732,6 +1708,7 @@ pub enum StoreOpVerifyErr {
     interfaces = [
         NResultsInterface<0>,
         AlignableOpInterface,
+        VolatilityOpInterface,
         NOpdsInterface<2>
     ],
     operands = (value, address: PointerType),
@@ -1751,24 +1728,6 @@ impl StoreOp {
                 0,
             ),
         }
-    }
-
-    /// Return whether this is a volatile store.
-    pub fn is_volatile(&self, ctx: &Context) -> bool {
-        self.get_operation()
-            .deref(ctx)
-            .attributes
-            .get::<BoolAttr>(&ATTR_KEY_LLVM_VOLATILE)
-            .map(|attr| attr.clone().into())
-            .unwrap_or(false)
-    }
-
-    /// Set whether this is a volatile store.
-    pub fn set_volatile(&self, ctx: &Context, is_volatile: bool) {
-        self.get_operation()
-            .deref_mut(ctx)
-            .attributes
-            .set(ATTR_KEY_LLVM_VOLATILE.clone(), BoolAttr::new(is_volatile));
     }
 }
 

--- a/pliron-llvm/src/to_llvm_ir.rs
+++ b/pliron-llvm/src/to_llvm_ir.rs
@@ -86,7 +86,7 @@ use crate::{
     },
     op_interfaces::{
         AlignableOpInterface, FastMathFlags, IsDeclaration, LlvmSymbolName, NNegFlag,
-        PointerTypeResult, SyncScopeInterface,
+        PointerTypeResult, SyncScopeInterface, VolatilityOpInterface,
     },
     ops::{
         AShrOp, AddOp, AddrSpaceCastOp, AddressOfOp, AllocaOp, AndOp, AtomicCmpxchgOp,

--- a/pliron-llvm/src/to_llvm_ir.rs
+++ b/pliron-llvm/src/to_llvm_ir.rs
@@ -78,7 +78,7 @@ use crate::{
         llvm_pointer_type_in_context, llvm_position_builder_at_end, llvm_replace_all_uses_with,
         llvm_scalable_vector_type, llvm_set_alignment, llvm_set_atomic_sync_scope_id,
         llvm_set_fast_math_flags, llvm_set_initializer, llvm_set_linkage, llvm_set_nneg,
-        llvm_set_ordering, llvm_struct_create_named, llvm_struct_set_body,
+        llvm_set_ordering, llvm_set_volatile, llvm_struct_create_named, llvm_struct_set_body,
         llvm_struct_type_in_context, llvm_type_of, llvm_vector_type, llvm_void_type_in_context,
     },
     metadata_conversions::to_llvm_ir::{
@@ -817,6 +817,7 @@ impl ToLLVMValue for LoadOp {
         if let Some(alignment) = self.alignment(ctx) {
             llvm_set_alignment(load_op, alignment);
         }
+        llvm_set_volatile(load_op, self.is_volatile(ctx));
         Ok(load_op)
     }
 }
@@ -835,6 +836,7 @@ impl ToLLVMValue for StoreOp {
         if let Some(alignment) = self.alignment(ctx) {
             llvm_set_alignment(store_op, alignment);
         }
+        llvm_set_volatile(store_op, self.is_volatile(ctx));
         Ok(store_op)
     }
 }

--- a/pliron-llvm/tests/ir_expect.rs
+++ b/pliron-llvm/tests/ir_expect.rs
@@ -718,31 +718,49 @@ fn llvm_ir_volatile_load_store_roundtrip() -> Result<()> {
     let llvm_ctx = LLVMContext::default();
     let ctx = &mut Context::new();
     let module_op = common::parse_llvm_ir_verify(ctx, &llvm_ctx, input, "volatile_load_store")?;
+    let printed = module_op.get_operation().disp(ctx).to_string();
 
-    let pliron_text = module_op.get_operation().disp(ctx).to_string();
-    expect!["2"].assert_eq(&pliron_text.matches("[volatile : true]").count().to_string());
+    expect![[r#"
+        builtin.module @volatile_load_store 
+        {
+          ^block1v1():
+            llvm.func @volatile_rw: llvm.func <builtin.integer i32(llvm.ptr (0), builtin.integer i32) variadic = false>
+              [llvm_function_linkage: llvm.linkage ExternalLinkage] 
+            {
+              ^entry_block2v1(v0: llvm.ptr (0), v1: builtin.integer i32):
+                v_v2 = llvm.load [volatile : true] v0 [align : 4] : builtin.integer i32 !0;
+                llvm.store [volatile : true] *v0 <- v1 [align : 4];
+                plain_v3 = llvm.load v0 [align : 4] : builtin.integer i32 !1;
+                llvm.store *v0 <- plain_v3 [align : 4];
+                llvm.return v_v2
+            }
+        }
 
-    // The printed Pliron form must itself round-trip through the parser. This also
-    // verifies that non-volatile load/store syntax remains unambiguous next to alignment.
+        outlined_attributes:
+        !0 = [builtin_given_names = builtin.given_names [v]]
+        !1 = [builtin_given_names = builtin.given_names [plain]]
+    "#]].assert_eq(&printed);
+
+    // Print and reparse.
     let reparsed_ctx = &mut Context::new();
-    let reparsed_module = common::parse_op_verify(reparsed_ctx, &pliron_text)?;
+    let reparsed_module = common::parse_op_verify::<ModuleOp>(reparsed_ctx, &printed)?;
 
     let out_llvm_ctx = LLVMContext::default();
     let out_mod = to_llvm_ir::convert_module(reparsed_ctx, &out_llvm_ctx, reparsed_module)?;
-    let out = out_mod.to_string();
 
-    let memory_op_summary = format!(
-        "load volatile: {}\nstore volatile: {}\nload: {}\nstore: {}",
-        out.matches("load volatile").count(),
-        out.matches("store volatile").count(),
-        out.matches("load i32").count(),
-        out.matches("store i32").count(),
-    );
     expect![[r#"
-        load volatile: 1
-        store volatile: 1
-        load: 1
-        store: 1"#]]
-    .assert_eq(&memory_op_summary);
+        ; ModuleID = 'volatile_load_store'
+        source_filename = "volatile_load_store"
+
+        define i32 @volatile_rw(ptr %0, i32 %1) {
+        entry_block2v1_block2v1:
+          %v_v2 = load volatile i32, ptr %0, align 4
+          store volatile i32 %1, ptr %0, align 4
+          %plain_v3 = load i32, ptr %0, align 4
+          store i32 %plain_v3, ptr %0, align 4
+          ret i32 %v_v2
+        }
+    "#]]
+    .assert_eq(&out_mod.to_string());
     Ok(())
 }

--- a/pliron-llvm/tests/ir_expect.rs
+++ b/pliron-llvm/tests/ir_expect.rs
@@ -19,7 +19,6 @@ use pliron_llvm::{
     from_llvm_ir,
     llvm_sys::core::LLVMContext,
     ops::{ConstantOpVerifyErr, SelectOpVerifyErr},
-    to_llvm_ir,
 };
 mod common;
 
@@ -728,8 +727,8 @@ fn llvm_ir_volatile_load_store_roundtrip() -> Result<()> {
               [llvm_function_linkage: llvm.linkage ExternalLinkage] 
             {
               ^entry_block2v1(v0: llvm.ptr (0), v1: builtin.integer i32):
-                v_v2 = llvm.load [volatile : true] v0 [align : 4] : builtin.integer i32 !0;
-                llvm.store [volatile : true] *v0 <- v1 [align : 4];
+                v_v2 = llvm.load v0 [volatile : true][align : 4] : builtin.integer i32 !0;
+                llvm.store *v0 <- v1 [volatile : true][align : 4];
                 plain_v3 = llvm.load v0 [align : 4] : builtin.integer i32 !1;
                 llvm.store *v0 <- plain_v3 [align : 4];
                 llvm.return v_v2
@@ -746,7 +745,7 @@ fn llvm_ir_volatile_load_store_roundtrip() -> Result<()> {
     let reparsed_module = common::parse_op_verify::<ModuleOp>(reparsed_ctx, &printed)?;
 
     let out_llvm_ctx = LLVMContext::default();
-    let out_mod = to_llvm_ir::convert_module(reparsed_ctx, &out_llvm_ctx, reparsed_module)?;
+    let out_mod = common::to_llvm_ir_verify(reparsed_ctx, &out_llvm_ctx, reparsed_module)?;
 
     expect![[r#"
         ; ModuleID = 'volatile_load_store'

--- a/pliron-llvm/tests/ir_expect.rs
+++ b/pliron-llvm/tests/ir_expect.rs
@@ -10,6 +10,7 @@ use pliron::{
     builtin::ops::ModuleOp,
     context::Context,
     init_env_logger_for_tests,
+    op::Op,
     printable::Printable,
     result::{Error, Result},
 };
@@ -18,8 +19,8 @@ use pliron_llvm::{
     from_llvm_ir,
     llvm_sys::core::LLVMContext,
     ops::{ConstantOpVerifyErr, SelectOpVerifyErr},
+    to_llvm_ir,
 };
-
 mod common;
 
 fn to_llvm_ir_o1(input: &str) -> Result<String> {
@@ -697,5 +698,42 @@ fn named_syncscopes_roundtrip() -> Result<()> {
         }
     "#]]
     .assert_eq(&out);
+    Ok(())
+}
+
+#[test]
+fn llvm_ir_volatile_load_store_roundtrip() -> Result<()> {
+    init_env_logger_for_tests!();
+    let input = r#"
+        define i32 @volatile_rw(ptr %p, i32 %x) {
+        entry:
+          %v = load volatile i32, ptr %p, align 4
+          store volatile i32 %x, ptr %p, align 4
+          %plain = load i32, ptr %p, align 4
+          store i32 %plain, ptr %p, align 4
+          ret i32 %v
+        }
+    "#;
+
+    let llvm_ctx = LLVMContext::default();
+    let ctx = &mut Context::new();
+    let module_op = common::parse_llvm_ir_verify(ctx, &llvm_ctx, input, "volatile_load_store")?;
+
+    let pliron_text = module_op.get_operation().disp(ctx).to_string();
+    assert_eq!(pliron_text.matches("[volatile : true]").count(), 2);
+
+    // The printed Pliron form must itself round-trip through the parser. This also
+    // verifies that non-volatile load/store syntax remains unambiguous next to alignment.
+    let reparsed_ctx = &mut Context::new();
+    let reparsed_module = common::parse_op_verify(reparsed_ctx, &pliron_text)?;
+
+    let out_llvm_ctx = LLVMContext::default();
+    let out_mod = to_llvm_ir::convert_module(reparsed_ctx, &out_llvm_ctx, reparsed_module)?;
+    let out = out_mod.to_string();
+
+    assert_eq!(out.matches("load volatile").count(), 1);
+    assert_eq!(out.matches("store volatile").count(), 1);
+    assert_eq!(out.matches("load i32").count(), 1);
+    assert_eq!(out.matches("store i32").count(), 1);
     Ok(())
 }

--- a/pliron-llvm/tests/ir_expect.rs
+++ b/pliron-llvm/tests/ir_expect.rs
@@ -720,7 +720,7 @@ fn llvm_ir_volatile_load_store_roundtrip() -> Result<()> {
     let module_op = common::parse_llvm_ir_verify(ctx, &llvm_ctx, input, "volatile_load_store")?;
 
     let pliron_text = module_op.get_operation().disp(ctx).to_string();
-    assert_eq!(pliron_text.matches("[volatile : true]").count(), 2);
+    expect!["2"].assert_eq(&pliron_text.matches("[volatile : true]").count().to_string());
 
     // The printed Pliron form must itself round-trip through the parser. This also
     // verifies that non-volatile load/store syntax remains unambiguous next to alignment.
@@ -731,9 +731,18 @@ fn llvm_ir_volatile_load_store_roundtrip() -> Result<()> {
     let out_mod = to_llvm_ir::convert_module(reparsed_ctx, &out_llvm_ctx, reparsed_module)?;
     let out = out_mod.to_string();
 
-    assert_eq!(out.matches("load volatile").count(), 1);
-    assert_eq!(out.matches("store volatile").count(), 1);
-    assert_eq!(out.matches("load i32").count(), 1);
-    assert_eq!(out.matches("store i32").count(), 1);
+    let memory_op_summary = format!(
+        "load volatile: {}\nstore volatile: {}\nload: {}\nstore: {}",
+        out.matches("load volatile").count(),
+        out.matches("store volatile").count(),
+        out.matches("load i32").count(),
+        out.matches("store i32").count(),
+    );
+    expect![[r#"
+        load volatile: 1
+        store volatile: 1
+        load: 1
+        store: 1"#]]
+    .assert_eq(&memory_op_summary);
     Ok(())
 }


### PR DESCRIPTION
## Description

Add support for preserving the `volatile` flag on ordinary, non-atomic LLVM load and store instructions across LLVM IR ↔ Pliron conversion.

Previously, importing a volatile load/store into Pliron lost the `volatile` property, so converting the operation back to LLVM IR produced a non-volatile memory operation.

## Changes

* Add a shared `llvm_volatile` attribute used by `LoadOp` and `StoreOp`.
* Add parsing and printing support for volatile loads and stores in the Pliron LLVM dialect.
* Preserve `volatile` when importing ordinary LLVM load/store instructions.
* Emit `volatile` when converting `LoadOp` and `StoreOp` back to LLVM IR.
* Add wrappers for LLVM's `LLVMGetVolatile` and `LLVMSetVolatile` C APIs.
* Add a round-trip test covering volatile and non-volatile loads/stores through:

  * LLVM IR → Pliron
  * printed Pliron → parsed Pliron
  * Pliron → LLVM IR

Atomic load/store handling is unchanged.

Loads and stores without the `volatile` attribute retain their existing representation and behavior.

## Testing

Validated locally against LLVM 23 / `llvm-sys` 231 with:

```text
./pre-ci.sh
```

This passes formatting, Clippy with warnings denied, the full workspace test suite, doctests, and documentation checks.

The targeted volatile round-trip test, existing `compile_run` tests, and `mem2reg` tests also pass.

## Checklist

* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
* [x] A human is involved in writing this PR description and will handle review interactions, per our [AI tool policy](../CONTRIBUTING.md).
* [x] I understand every part of this change (including any AI-generated code) and can explain the reasoning behind it.
* [x] Intrusive / large changes were discussed on Discord before this PR.
* [x] `pre-ci.sh` passes locally.
