### PR TITLE
`ConstantOp::new` must take `Box<TypedAttrInterface>` as its input

### DIFF
--- a/pliron-derive/src/derive_decontext.rs
+++ b/pliron-derive/src/derive_decontext.rs
@@ -268,6 +268,7 @@ pub(crate) fn derive_clone_attribute_into_context(input: TokenStream) -> syn::Re
         item_impl.into_token_stream(),
         interface_verifiers_slice,
         all_verifiers_fn_type,
+        interfaces::RegisterBoxedCast::Register,
     )
 }
 
@@ -300,6 +301,7 @@ pub(crate) fn derive_clone_type_into_context(input: TokenStream) -> syn::Result<
         item_impl.into_token_stream(),
         interface_verifiers_slice,
         all_verifiers_fn_type,
+        interfaces::RegisterBoxedCast::Skip,
     )
 }
 
@@ -665,6 +667,9 @@ mod tests {
                 }
             }
             ::pliron::type_to_trait!(Foo, ::pliron::irbuild::decontext::CloneAttributeIntoContext);
+            ::pliron::boxed_type_to_trait!(
+                Foo, ::pliron::irbuild::decontext::CloneAttributeIntoContext
+            );
             const _: () = {
                 #[cfg_attr(
                     not(target_family = "wasm"),

--- a/pliron-derive/src/interfaces.rs
+++ b/pliron-derive/src/interfaces.rs
@@ -87,13 +87,22 @@ pub(crate) fn interface_define(
     Ok(output)
 }
 
+/// Whether an interface impl must also be registered for casting boxed objects
+/// (i.e., with `boxed_type_to_trait!`, in addition to `type_to_trait!`).
+pub(crate) enum RegisterBoxedCast {
+    Register,
+    Skip,
+}
+
 /// This macro does two things:
-/// 1. Mark that the rust type be castable to the interface via type_to_trait.
+/// 1. Mark that the rust type be castable to the interface via `type_to_trait!`
+///    (and via `boxed_type_to_trait!` when [RegisterBoxedCast::Register] is specified).
 /// 2. Register the trait verifier in the rust type's list of interface verifiers.
 pub(crate) fn interface_impl(
     input: proc_macro2::TokenStream,
     interface_verifiers_slice: Path,
     all_verifiers_fn_type: Path,
+    register_boxed_cast: RegisterBoxedCast,
 ) -> Result<proc_macro2::TokenStream> {
     let r#impl = syn::parse2::<ItemImpl>(input)?;
 
@@ -112,9 +121,14 @@ pub(crate) fn interface_impl(
     }
 
     let rust_ty = (*r#impl.self_ty).clone();
-    let trait_cast = quote! {
+    let mut trait_cast = quote! {
         ::pliron::type_to_trait!(#rust_ty, #intr_name);
     };
+    if matches!(register_boxed_cast, RegisterBoxedCast::Register) {
+        trait_cast.extend(quote! {
+            ::pliron::boxed_type_to_trait!(#rust_ty, #intr_name);
+        });
+    }
     let verifiers_entry = quote! {
         const _: () = {
             #[cfg_attr(not(target_family = "wasm"), ::pliron::linkme::distributed_slice(#interface_verifiers_slice), linkme(crate = ::pliron::linkme))]

--- a/pliron-derive/src/lib.rs
+++ b/pliron-derive/src/lib.rs
@@ -672,6 +672,7 @@ pub fn op_interface_impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
         item.into(),
         interface_verifiers_slice,
         all_verifiers_fn_type,
+        interfaces::RegisterBoxedCast::Skip,
     ))
 }
 
@@ -1011,6 +1012,7 @@ pub fn attr_interface_impl(_attr: TokenStream, item: TokenStream) -> TokenStream
         item.into(),
         interface_verifiers_slice,
         all_verifiers_fn_type,
+        interfaces::RegisterBoxedCast::Register,
     ))
 }
 
@@ -1116,6 +1118,7 @@ pub fn type_interface_impl(_attr: TokenStream, item: TokenStream) -> TokenStream
         item.into(),
         interface_verifiers_slice,
         all_verifiers_fn_type,
+        interfaces::RegisterBoxedCast::Skip,
     ))
 }
 

--- a/pliron-llvm/src/builtin_to_llvm.rs
+++ b/pliron-llvm/src/builtin_to_llvm.rs
@@ -88,7 +88,7 @@ impl ToLLVMDialect for BuiltinConstantOp {
         rewriter: &mut DialectConversionRewriter,
         _operands_info: &OperandsInfo,
     ) -> Result<()> {
-        let const_value = self.get_value(ctx);
+        let const_value = pliron::dyn_clone::clone_box(&*self.get_value(ctx));
 
         // Create the LLVM constant operation with the same value
         let llvm_const = LLVMConstantOp::new(ctx, const_value);

--- a/pliron-llvm/src/from_llvm_ir.rs
+++ b/pliron-llvm/src/from_llvm_ir.rs
@@ -10,7 +10,7 @@ use llvm_sys::{
     LLVMRealPredicate, LLVMTypeKind, LLVMValueKind,
 };
 use pliron::{
-    attribute::{AttrObj, boxed_attr_cast},
+    attribute::{AttrObj, Attribute, boxed_attr_cast},
     basic_block::BasicBlock,
     builtin::{
         attributes::{FPDoubleAttr, FPHalfAttr, FPSingleAttr, IntegerAttr, StringAttr},
@@ -548,7 +548,8 @@ fn get_const_op_as_int(ctx: &Context, val: Value) -> Option<IntegerAttr> {
     let defining_op = val.defining_op()?;
 
     Operation::get_op::<ConstantOp>(defining_op, ctx).and_then(|const_op| {
-        (const_op.get_value(ctx) as AttrObj)
+        let value = const_op.get_value(ctx);
+        (&*value as &dyn Attribute)
             .downcast_ref::<IntegerAttr>()
             .cloned()
     })

--- a/pliron-llvm/src/from_llvm_ir.rs
+++ b/pliron-llvm/src/from_llvm_ir.rs
@@ -10,7 +10,7 @@ use llvm_sys::{
     LLVMRealPredicate, LLVMTypeKind, LLVMValueKind,
 };
 use pliron::{
-    attribute::AttrObj,
+    attribute::{AttrObj, boxed_attr_cast},
     basic_block::BasicBlock,
     builtin::{
         attributes::{FPDoubleAttr, FPHalfAttr, FPSingleAttr, IntegerAttr, StringAttr},
@@ -548,8 +548,7 @@ fn get_const_op_as_int(ctx: &Context, val: Value) -> Option<IntegerAttr> {
     let defining_op = val.defining_op()?;
 
     Operation::get_op::<ConstantOp>(defining_op, ctx).and_then(|const_op| {
-        const_op
-            .get_value(ctx)
+        (const_op.get_value(ctx) as AttrObj)
             .downcast_ref::<IntegerAttr>()
             .cloned()
     })
@@ -570,7 +569,7 @@ fn const_llvm_value_to_const_op(
     cctx: &mut ConversionContext,
     val: LLVMValue,
 ) -> Result<bool> {
-    let Some(attr) = const_llvm_value_to_attr(ctx, cctx, val)? else {
+    let Some(attr) = const_llvm_value_to_attr(ctx, cctx, val)?.and_then(boxed_attr_cast) else {
         return Ok(false);
     };
     let const_op = ConstantOp::new(ctx, attr);

--- a/pliron-llvm/src/interface_impls.rs
+++ b/pliron-llvm/src/interface_impls.rs
@@ -347,7 +347,9 @@ impl ConstFoldInterface for ConstantOp {
         ctx: &Context,
         _operand_attrs: &[Option<AttrObj>],
     ) -> Vec<Option<AttrObj>> {
-        vec![Some(self.get_value(ctx))]
+        vec![Some(
+            pliron::dyn_clone::clone_box(&*self.get_value(ctx)) as AttrObj
+        )]
     }
 
     fn fold_in_place(

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -10,11 +10,11 @@ use alloc::{
     vec,
     vec::Vec,
 };
-use core::num::NonZero;
+use core::{cell::Ref, num::NonZero};
 
 use pliron::{
     arg_err_noloc,
-    attribute::{AttrObj, Attribute, AttributeDict, attr_cast, attr_impls, boxed_attr_cast},
+    attribute::{AttrObj, Attribute, AttributeDict, attr_cast, attr_impls},
     basic_block::BasicBlock,
     builtin::{
         attr_interfaces::{FloatAttr, TypedAttrInterface},
@@ -2408,9 +2408,18 @@ pub struct ConstantOp;
 
 impl ConstantOp {
     /// Get the constant value that this Op defines.
-    pub fn get_value(&self, ctx: &Context) -> Box<dyn TypedAttrInterface> {
-        let attr = self.get_attr_llvm_constant_value(ctx).unwrap().clone();
-        boxed_attr_cast(attr).unwrap()
+    /// The [Ref] is a borrow of the containing [Operation] object.
+    ///
+    /// Use [pliron::dyn_clone::clone_box] to clone the value if required.
+    pub fn get_value<'a>(&self, ctx: &'a Context) -> Ref<'a, dyn TypedAttrInterface> {
+        Ref::map(
+            self.get_attr_llvm_constant_value(ctx)
+                .expect("ConstantOp must have a value attribute"),
+            |attr| {
+                attr_cast::<dyn TypedAttrInterface>(&**attr)
+                    .expect("ConstantOp's value attribute must impl TypedAttrInterface")
+            },
+        )
     }
 
     /// Create a new [ConstantOp] holding `value`.

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -14,7 +14,7 @@ use core::num::NonZero;
 
 use pliron::{
     arg_err_noloc,
-    attribute::{AttrObj, AttributeDict, attr_cast, attr_impls},
+    attribute::{AttrObj, Attribute, AttributeDict, attr_cast, attr_impls, boxed_attr_cast},
     basic_block::BasicBlock,
     builtin::{
         attr_interfaces::{FloatAttr, TypedAttrInterface},
@@ -2408,17 +2408,14 @@ pub struct ConstantOp;
 
 impl ConstantOp {
     /// Get the constant value that this Op defines.
-    pub fn get_value(&self, ctx: &Context) -> AttrObj {
-        self.get_attr_llvm_constant_value(ctx).unwrap().clone()
+    pub fn get_value(&self, ctx: &Context) -> Box<dyn TypedAttrInterface> {
+        let attr = self.get_attr_llvm_constant_value(ctx).unwrap().clone();
+        boxed_attr_cast(attr).unwrap()
     }
 
     /// Create a new [ConstantOp] holding `value`.
-    ///
-    /// **Panics** if `value` doesn't implement [TypedAttrInterface].
-    pub fn new(ctx: &mut Context, value: AttrObj) -> Self {
-        let result_type = attr_cast::<dyn TypedAttrInterface>(&*value)
-            .expect("ConstantOp value must provide TypedAttrInterface")
-            .get_type(ctx);
+    pub fn new(ctx: &mut Context, value: Box<dyn TypedAttrInterface>) -> Self {
+        let result_type = value.get_type(ctx);
         let op = Operation::new(
             ctx,
             Self::get_concrete_op_info(),
@@ -2435,6 +2432,8 @@ impl ConstantOp {
 
 #[derive(Error, Debug)]
 pub enum ConstantOpVerifyErr {
+    #[error("ConstantOp does not have a value attribute")]
+    MissingValue,
     #[error("{0} not allowed on a ConstantOp")]
     InvalidValue(String),
     #[error("The value attribute is of type {0}, but the constant is of type {1}")]
@@ -2444,11 +2443,15 @@ pub enum ConstantOpVerifyErr {
 impl Verify for ConstantOp {
     fn verify(&self, ctx: &Context) -> Result<()> {
         let loc = self.loc(ctx);
-        let value = self.get_value(ctx);
         let result_type = self.result_type(ctx);
 
+        let Some(value) = self.get_attr_llvm_constant_value(ctx) else {
+            return verify_err!(loc, ConstantOpVerifyErr::MissingValue);
+        };
+        let value: &dyn Attribute = &**value;
+
         if !(value.is::<IntegerAttr>()
-            || attr_impls::<dyn FloatAttr>(&*value)
+            || attr_impls::<dyn FloatAttr>(value)
             || value.is::<AggregateAttr>()
             || value.is::<SplatAttr>()
             || value.is::<BytesAttr>()
@@ -2460,14 +2463,14 @@ impl Verify for ConstantOp {
             )?;
         }
 
-        let value_type = attr_cast::<dyn TypedAttrInterface>(&*value)
-            .map(|typed| typed.get_type(ctx))
-            .expect("All allowed attributes (above) implement TypedAttrInterface");
-        if value_type != result_type {
+        let value = attr_cast::<dyn TypedAttrInterface>(value)
+            .expect("All attributes we allow above implement TypedAttrInterface");
+
+        if value.get_type(ctx) != result_type {
             verify_err!(
                 loc,
                 ConstantOpVerifyErr::ResultTypeMismatch(
-                    value_type.disp(ctx).to_string(),
+                    value.get_type(ctx).disp(ctx).to_string(),
                     result_type.disp(ctx).to_string()
                 )
             )?

--- a/pliron-llvm/src/to_llvm_ir.rs
+++ b/pliron-llvm/src/to_llvm_ir.rs
@@ -2410,7 +2410,7 @@ impl OpToLLVMConstValue for ConstantOp {
         llvm_ctx: &LLVMContext,
         cctx: &mut ConversionContext,
     ) -> Result<LLVMValue> {
-        let value = self.get_value(ctx);
+        let value = self.get_value(ctx) as AttrObj;
         const_attr_to_llvm_constant(&value, Some(self.loc(ctx)), ctx, llvm_ctx, cctx)
     }
 }

--- a/pliron-llvm/src/to_llvm_ir.rs
+++ b/pliron-llvm/src/to_llvm_ir.rs
@@ -2410,7 +2410,9 @@ impl OpToLLVMConstValue for ConstantOp {
         llvm_ctx: &LLVMContext,
         cctx: &mut ConversionContext,
     ) -> Result<LLVMValue> {
-        let value = self.get_value(ctx) as AttrObj;
+        let value = self
+            .get_attr_llvm_constant_value(ctx)
+            .expect("ConstantOp must have a value attribute");
         const_attr_to_llvm_constant(&value, Some(self.loc(ctx)), ctx, llvm_ctx, cctx)
     }
 }

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -409,6 +409,53 @@ pub fn attr_impls_static<A: Attribute, I: ?Sized + AttrInterfaceMarker + 'static
     impls_trait_static::<A, I>()
 }
 
+/// Cast a boxed [Attribute] object to a boxed interface object.
+///
+/// Usage:
+///
+/// ```
+/// use pliron::{
+///     attribute::{Attribute, boxed_attr_cast},
+///     builtin::{
+///         attr_interfaces::{FloatAttr, TypedAttrInterface},
+///         attributes::IntegerAttr,
+///         types::{IntegerType, Signedness},
+///     },
+///     context::Context,
+///     utils::apint::{APInt, bw},
+/// };
+/// let ctx = &Context::new();
+///
+/// let i64_ty = IntegerType::get(ctx, 64, Signedness::Signed);
+/// let int_attr = || -> Box<dyn Attribute> {
+///     Box::new(IntegerAttr::new(i64_ty, APInt::from_i64(42, bw(64))))
+/// };
+///
+/// let typed = boxed_attr_cast::<dyn TypedAttrInterface>(int_attr())
+///     .expect("IntegerAttr implements TypedAttrInterface");
+/// assert_eq!(typed.get_type(ctx), i64_ty.into());
+///
+/// // IntegerAttr isn't a float attribute, so the cast fails.
+/// assert!(boxed_attr_cast::<dyn FloatAttr>(int_attr()).is_none());
+/// ```
+///
+/// Casting to concrete [Attribute] types are intentionally rejected.
+/// ```compile_fail
+/// use pliron::attribute::{Attribute, boxed_attr_cast};
+/// use pliron::builtin::attributes::IntegerAttr;
+///
+/// fn wrong_cast(attr: Box<dyn Attribute>) {
+///     let _ = boxed_attr_cast::<IntegerAttr>(attr);
+/// }
+/// ```
+/// Use [downcast_rs](https://docs.rs/downcast-rs/latest/downcast_rs/#example-without-generics)
+/// to cast to concrete [Attribute] types.
+pub fn boxed_attr_cast<T: ?Sized + AttrInterfaceMarker + 'static>(
+    attr: Box<dyn Attribute>,
+) -> Option<Box<T>> {
+    crate::utils::trait_cast::boxed_any_to_trait::<T>(attr as Box<dyn core::any::Any>)
+}
+
 /// If an [Attribute] impls [TypedAttrInterface], get its [Type](crate::type::Type).
 ///
 /// ```

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -39,21 +39,13 @@
 //! [AttrObj]s can be downcasted to their concrete types using
 //! [downcast_rs](https://docs.rs/downcast-rs/latest/downcast_rs/#example-without-generics).
 
-use alloc::{boxed::Box, string::String, vec::Vec};
-use core::{
-    fmt::{Debug, Display},
-    hash::{Hash, Hasher},
-    ops::Deref,
-};
-use downcast_rs::{Downcast, impl_downcast};
-use dyn_clone::DynClone;
-
 use crate::{
     builtin::attr_interfaces::{OutlinedAttr, TypedAttrInterface},
     combine::{Parser, parser, token},
     common_traits::Verify,
     context::{Context, collect_deduped_interface_verifiers},
     dialect::{Dialect, DialectName},
+    dyn_clone::DynClone,
     identifier::Identifier,
     impl_printable_for_display, input_err,
     irfmt::{
@@ -72,6 +64,13 @@ use crate::{
         trait_cast::impls_trait_static,
     },
 };
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::{
+    fmt::{Debug, Display},
+    hash::{Hash, Hasher},
+    ops::Deref,
+};
+use downcast_rs::{Downcast, impl_downcast};
 
 /// Convenience type to easily print and parse key-value pairs in an [AttributeDict].
 #[derive(Clone)]

--- a/src/builtin/interface_impls.rs
+++ b/src/builtin/interface_impls.rs
@@ -21,7 +21,9 @@ impl ConstFoldInterface for ConstantOp {
         ctx: &Context,
         _operand_attrs: &[Option<AttrObj>],
     ) -> Vec<Option<AttrObj>> {
-        vec![Some(self.get_value(ctx))]
+        vec![Some(
+            pliron::dyn_clone::clone_box(&*self.get_value(ctx)) as AttrObj
+        )]
     }
 
     fn fold_in_place(

--- a/src/builtin/op_interfaces.rs
+++ b/src/builtin/op_interfaces.rs
@@ -651,7 +651,7 @@ pub trait SymbolTableInterface: SingleBlockRegionInterface + OneRegionInterface 
             symbol_table_collection: SymbolTableCollection::new(),
             res: Ok(()),
         };
-        walk_symbol_table(dyn_clone::clone_box(op), ctx, &mut state, callback);
+        walk_symbol_table(pliron::dyn_clone::clone_box(op), ctx, &mut state, callback);
         state.res
     }
 }

--- a/src/builtin/ops.rs
+++ b/src/builtin/ops.rs
@@ -13,7 +13,7 @@ use super::{
     types::{FunctionType, UnitType},
 };
 use crate::{
-    attribute::{Attribute, AttributeDict, attr_cast, attr_impls, boxed_attr_cast},
+    attribute::{Attribute, AttributeDict, attr_cast, attr_impls},
     basic_block::BasicBlock,
     builtin::{
         op_interfaces::{
@@ -49,6 +49,7 @@ use alloc::{
     vec,
     vec::Vec,
 };
+use core::cell::Ref;
 use pliron::derive::{op_interface_impl, pliron_op};
 use thiserror::Error;
 
@@ -347,9 +348,18 @@ impl Verify for ConstantOp {
 
 impl ConstantOp {
     /// Get the constant value that this Op defines.
-    pub fn get_value(&self, ctx: &Context) -> Box<dyn TypedAttrInterface> {
-        let attr = self.get_attr_builtin_constant_value(ctx).unwrap().clone();
-        boxed_attr_cast(attr).unwrap()
+    /// The [Ref] is a borrow of the containing [Operation] object.
+    ///
+    /// Use [pliron::dyn_clone::clone_box] to clone the value if required.
+    pub fn get_value<'a>(&self, ctx: &'a Context) -> Ref<'a, dyn TypedAttrInterface> {
+        Ref::map(
+            self.get_attr_builtin_constant_value(ctx)
+                .expect("ConstantOp must have a value attribute"),
+            |attr| {
+                attr_cast::<dyn TypedAttrInterface>(&**attr)
+                    .expect("ConstantOp's value attribute must impl TypedAttrInterface")
+            },
+        )
     }
 
     /// Create a new [ConstantOp].

--- a/src/builtin/ops.rs
+++ b/src/builtin/ops.rs
@@ -13,7 +13,7 @@ use super::{
     types::{FunctionType, UnitType},
 };
 use crate::{
-    attribute::{Attribute, AttributeDict, attr_cast, attr_impls},
+    attribute::{Attribute, AttributeDict, attr_cast},
     basic_block::BasicBlock,
     builtin::{
         op_interfaces::{
@@ -327,19 +327,33 @@ pub enum ConstantOpVerifyErr {
     MissingValue,
     #[error("ConstantOp's value attribute {0} does not implement TypedAttrInterface")]
     ValueNotTyped(String),
+    #[error("The value attribute is of type {0}, but the constant is of type {1}")]
+    ResultTypeMismatch(String, String),
 }
 
 impl Verify for ConstantOp {
     fn verify(&self, ctx: &Context) -> Result<()> {
         let loc = self.loc(ctx);
+        let result_type = self.result_type(ctx);
+
         let Some(value) = self.get_attr_builtin_constant_value(ctx) else {
             return verify_err!(loc, ConstantOpVerifyErr::MissingValue);
         };
         let value: &dyn Attribute = &**value;
-        if !attr_impls::<dyn TypedAttrInterface>(value) {
+        let Some(value) = attr_cast::<dyn TypedAttrInterface>(value) else {
             return verify_err!(
                 loc,
                 ConstantOpVerifyErr::ValueNotTyped(value.get_attr_id().to_string())
+            );
+        };
+
+        if value.get_type(ctx) != result_type {
+            return verify_err!(
+                loc,
+                ConstantOpVerifyErr::ResultTypeMismatch(
+                    value.get_type(ctx).disp(ctx).to_string(),
+                    result_type.disp(ctx).to_string()
+                )
             );
         }
         Ok(())

--- a/src/builtin/ops.rs
+++ b/src/builtin/ops.rs
@@ -13,7 +13,7 @@ use super::{
     types::{FunctionType, UnitType},
 };
 use crate::{
-    attribute::{AttrObj, AttributeDict, attr_cast},
+    attribute::{Attribute, AttributeDict, attr_cast, attr_impls, boxed_attr_cast},
     basic_block::BasicBlock,
     builtin::{
         op_interfaces::{
@@ -44,6 +44,7 @@ use crate::{
     verify_err,
 };
 use alloc::{
+    boxed::Box,
     string::{String, ToString},
     vec,
     vec::Vec,
@@ -316,21 +317,44 @@ impl Verify for FuncOp {
     format = "`<` $builtin_constant_value `>` ` : ` type($0)",
     interfaces = [NOpdsInterface<0>, OneResultInterface],
     attributes = (builtin_constant_value),
-    verifier = "succ"
 )]
 pub struct ConstantOp;
 
+#[derive(Error, Debug)]
+pub enum ConstantOpVerifyErr {
+    #[error("ConstantOp does not have a value attribute")]
+    MissingValue,
+    #[error("ConstantOp's value attribute {0} does not implement TypedAttrInterface")]
+    ValueNotTyped(String),
+}
+
+impl Verify for ConstantOp {
+    fn verify(&self, ctx: &Context) -> Result<()> {
+        let loc = self.loc(ctx);
+        let Some(value) = self.get_attr_builtin_constant_value(ctx) else {
+            return verify_err!(loc, ConstantOpVerifyErr::MissingValue);
+        };
+        let value: &dyn Attribute = &**value;
+        if !attr_impls::<dyn TypedAttrInterface>(value) {
+            return verify_err!(
+                loc,
+                ConstantOpVerifyErr::ValueNotTyped(value.get_attr_id().to_string())
+            );
+        }
+        Ok(())
+    }
+}
+
 impl ConstantOp {
     /// Get the constant value that this Op defines.
-    pub fn get_value(&self, ctx: &Context) -> AttrObj {
-        self.get_attr_builtin_constant_value(ctx).unwrap().clone()
+    pub fn get_value(&self, ctx: &Context) -> Box<dyn TypedAttrInterface> {
+        let attr = self.get_attr_builtin_constant_value(ctx).unwrap().clone();
+        boxed_attr_cast(attr).unwrap()
     }
 
     /// Create a new [ConstantOp].
-    pub fn new(ctx: &mut Context, value: AttrObj) -> Self {
-        let result_type = attr_cast::<dyn TypedAttrInterface>(&*value)
-            .expect("ConstantOp const value must provide TypedAttrInterface")
-            .get_type(ctx);
+    pub fn new(ctx: &mut Context, value: Box<dyn TypedAttrInterface>) -> Self {
+        let result_type = value.get_type(ctx);
         let op = Operation::new(
             ctx,
             Self::get_concrete_op_info(),

--- a/src/op.rs
+++ b/src/op.rs
@@ -45,7 +45,6 @@ use core::{
     ops::Deref,
 };
 use downcast_rs::{Downcast, impl_downcast};
-use dyn_clone::DynClone;
 use thiserror::Error;
 
 use crate::{
@@ -58,6 +57,7 @@ use crate::{
     common_traits::{Named, Verify},
     context::{Context, Ptr, collect_deduped_interface_verifiers},
     dialect::{Dialect, DialectName},
+    dyn_clone::DynClone,
     identifier::Identifier,
     impl_printable_for_display, input_err,
     irfmt::{

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -69,7 +69,7 @@ impl SymbolTable {
             {
                 let sym = sym_op.get_symbol_name(ctx);
                 if let Some(prev_op) =
-                    symbol_table.insert(sym.clone(), dyn_clone::clone_box(sym_op))
+                    symbol_table.insert(sym.clone(), pliron::dyn_clone::clone_box(sym_op))
                 {
                     // It's the job of the verifier to have caught this. So we panic.
                     panic!(
@@ -249,7 +249,7 @@ pub fn nearest_symbol_table(
         if let Some(symbol_table) =
             op_cast::<dyn SymbolTableInterface>(Operation::get_op_dyn(op, ctx).as_ref())
         {
-            return Some(dyn_clone::clone_box(symbol_table));
+            return Some(pliron::dyn_clone::clone_box(symbol_table));
         }
         op = op.deref(ctx).get_parent_op(ctx)?;
     }

--- a/src/utils/trait_cast.rs
+++ b/src/utils/trait_cast.rs
@@ -5,11 +5,10 @@
 //! for traits that the type contained by the [Any] object implements.
 //!
 //! A user must specify [type_to_trait](crate::type_to_trait) for a type that implements
-//! a trait and needs to be casted to it, and then use [any_to_trait]
-//! to do the actual cast.
+//! a trait and needs to be casted to it, and then use [any_to_trait] to do the actual cast.
 //!
-//! Similarly, a user must specify [boxed_type_to_trait](crate::boxed_type_to_trait) for a
-//! type whose boxed objects (`Box<dyn Any>`) need to be casted to boxed trait objects
+//! Similarly, a user must specify [boxed_type_to_trait](crate::boxed_type_to_trait) for
+//! a type whose boxed objects (`Box<dyn Any>`) need to be casted to boxed trait objects
 //! (`Box<dyn Trait>`), and then use [boxed_any_to_trait] to do the actual cast.
 //!
 //! See their documentation for details and examples.

--- a/src/utils/trait_cast.rs
+++ b/src/utils/trait_cast.rs
@@ -6,7 +6,13 @@
 //!
 //! A user must specify [type_to_trait](crate::type_to_trait) for a type that implements
 //! a trait and needs to be casted to it, and then use [any_to_trait]
-//! to do the actual cast. See their documentation for details and examples.
+//! to do the actual cast.
+//!
+//! Similarly, a user must specify [boxed_type_to_trait](crate::boxed_type_to_trait) for a
+//! type whose boxed objects (`Box<dyn Any>`) need to be casted to boxed trait objects
+//! (`Box<dyn Trait>`), and then use [boxed_any_to_trait] to do the actual cast.
+//!
+//! See their documentation for details and examples.
 
 use core::any::{Any, TypeId};
 
@@ -21,7 +27,6 @@ use crate::{std_deps::sync::LazyLock, utils::table::HMap};
 /// To cast from `dyn Trait1` to `dyn Trait2` (when the underlying type implements both),
 /// the user may use [downcast_rs] to easily upcast from `dyn Trait1` to [Any],
 /// and then use [any_to_trait] to cast to `dyn Trait2`.
-///
 /// Example:
 /// ```
 /// # use pliron::{type_to_trait, utils::trait_cast::any_to_trait};
@@ -50,54 +55,12 @@ use crate::{std_deps::sync::LazyLock, utils::table::HMap};
 pub fn any_to_trait<T: ?Sized + 'static>(r: &dyn Any) -> Option<&T> {
     TRAIT_CASTERS_MAP
         .get(&(r.type_id(), TypeId::of::<T>()))
-        .map(|info| {
-            (*info
-                .caster
+        .map(|caster| {
+            ((**caster)
                 // The caster function is set by `type_to_trait!`, and can only be of this type.
                 .downcast_ref::<for<'a> fn(&'a (dyn Any + 'static)) -> &'a T>()
                 .unwrap())(r)
         })
-}
-
-/// Cast a `Box<dyn Any>` object to a `Box<dyn Trait>` for any
-/// trait that the contained (in [Any]) type implements, and for which
-/// [type_to_trait](crate::type_to_trait) has been specified.
-///
-/// To cast from `Box<dyn Trait1>` to `Box<dyn Trait2>` (when the underlying type implements
-/// both), the user may use [downcast_rs] to easily upcast from `Box<dyn Trait1>` to
-/// `Box<dyn Any>`, and then use [boxed_any_to_trait] to cast to `Box<dyn Trait2>`.
-///
-/// Example:
-/// ```
-/// # use pliron::{type_to_trait, utils::trait_cast::boxed_any_to_trait};
-/// # use pliron::alloc::boxed::Box;
-/// # use core::any::Any;
-///
-/// trait Trait1 {}
-/// trait Trait2 {}
-///
-/// struct S;
-/// impl Trait1 for S {}
-/// impl Trait2 for S {}
-///
-/// type_to_trait!(S, Trait2);
-///
-/// let s1: Box<dyn Any> = Box::new(S);
-/// boxed_any_to_trait::<dyn Trait2>(s1).expect("Expected S to implement Trait2");
-///
-/// struct S2;
-/// let s2: Box<dyn Any> = Box::new(S2);
-/// assert!(boxed_any_to_trait::<dyn Trait2>(s2).is_none(), "S2 does not implement Trait2");
-/// ```
-pub fn boxed_any_to_trait<T: ?Sized + 'static>(r: Box<dyn Any>) -> Option<Box<T>> {
-    let key = ((*r).type_id(), TypeId::of::<T>());
-    TRAIT_CASTERS_MAP.get(&key).map(|info| {
-        (*info
-            .box_caster
-            // The caster function is set by `type_to_trait!`, and can only be of this type.
-            .downcast_ref::<fn(Box<dyn Any>) -> Box<T>>()
-            .unwrap())(r)
-    })
 }
 
 /// Check if type `T` was registered to be casted to trait `I`
@@ -126,10 +89,8 @@ pub struct TraitCasterInfo {
     pub from: TypeId,
     /// The trait to which we cast.
     pub to: TypeId,
-    /// The cast function pointer, for casting a `&dyn Any` to a `&dyn Trait`.
+    /// The cast function pointer.
     pub caster: &'static (dyn Any + Sync + Send),
-    /// The cast function pointer, for casting a `Box<dyn Any>` to a `Box<dyn Trait>`.
-    pub box_caster: &'static (dyn Any + Sync + Send),
 }
 
 #[cfg(not(target_family = "wasm"))]
@@ -150,8 +111,8 @@ pub mod statics {
 
     ::pliron::inventory::collect!(&'static TraitCasterInfo);
 
-    pub fn get_trait_casters() -> impl Iterator<Item = &'static TraitCasterInfo> {
-        ::pliron::inventory::iter::<&'static TraitCasterInfo>().copied()
+    pub fn get_trait_casters() -> impl Iterator<Item = &'static &'static TraitCasterInfo> {
+        ::pliron::inventory::iter::<&'static TraitCasterInfo>()
     }
 }
 
@@ -159,12 +120,13 @@ pub use statics::*;
 
 #[doc(hidden)]
 /// A map of all the trait casters, indexed by the type_id of the object
-/// and the type_id of the trait to cast to. The map's values hold the
-/// cast function pointers.
-static TRAIT_CASTERS_MAP: LazyLock<HMap<(TypeId, TypeId), &'static TraitCasterInfo>> =
+/// and the type_id of the trait to cast to. The map's values are
+/// the cast function pointers. This is used to avoid having to search
+/// through the distributed slice every time we want to cast an object.
+static TRAIT_CASTERS_MAP: LazyLock<HMap<(TypeId, TypeId), &'static (dyn Any + Sync + Send)>> =
     LazyLock::new(|| {
         get_trait_casters()
-            .map(|info| ((info.from, info.to), info))
+            .map(|lazy| ((lazy.from, lazy.to), lazy.caster))
             .collect()
     });
 
@@ -207,12 +169,6 @@ macro_rules! type_to_trait {
                             &'a (dyn core::any::Any + 'static),
                         ) -> &'a (dyn $to_trait_name + 'static))
                         as &'static (dyn core::any::Any + Sync + Send),
-                    box_caster: &(boxed_cast_to_trait
-                        as fn(
-                            $crate::alloc::boxed::Box<dyn core::any::Any + 'static>,
-                        )
-                            -> $crate::alloc::boxed::Box<dyn $to_trait_name + 'static>)
-                        as &'static (dyn core::any::Any + Sync + Send),
                 };
 
             #[cfg(target_family = "wasm")]
@@ -228,13 +184,155 @@ macro_rules! type_to_trait {
                 // in `type_to_trait!` or `any_to_trait`, not their usage.
                 r.downcast_ref::<$ty_name>().unwrap() as &dyn $to_trait_name
             }
+        };
+    };
+}
+
+/// Cast a `Box<dyn Any>` object to a `Box<dyn Trait>` object for any
+/// trait that the contained (in [Any]) type implements, and for which
+/// [boxed_type_to_trait](crate::boxed_type_to_trait) has been specified.
+///
+/// To cast from `Box<dyn Trait1>` to `Box<dyn Trait2>` (when the underlying type implements
+/// both), the user may use [downcast_rs] to easily upcast from `Box<dyn Trait1>` to
+/// `Box<dyn Any>`, and then use [boxed_any_to_trait] to cast to `Box<dyn Trait2>`.
+///
+/// Example:
+/// ```
+/// # use pliron::{boxed_type_to_trait, utils::trait_cast::boxed_any_to_trait};
+/// # use pliron::alloc::boxed::Box;
+/// # use core::any::Any;
+///
+/// trait Trait1 {}
+/// trait Trait2 {}
+///
+/// struct S;
+/// impl Trait1 for S {}
+/// impl Trait2 for S {}
+///
+/// boxed_type_to_trait!(S, Trait2);
+///
+/// let s1: Box<dyn Any> = Box::new(S);
+/// boxed_any_to_trait::<dyn Trait2>(s1).expect("Expected S to implement Trait2");
+///
+/// struct S2;
+/// let s2: Box<dyn Any> = Box::new(S2);
+/// assert!(boxed_any_to_trait::<dyn Trait2>(s2).is_none(), "S2 does not implement Trait2");
+/// ```
+pub fn boxed_any_to_trait<T: ?Sized + 'static>(r: Box<dyn Any>) -> Option<Box<T>> {
+    BOXED_TRAIT_CASTERS_MAP
+        .get(&((*r).type_id(), TypeId::of::<T>()))
+        .map(|caster| {
+            ((**caster)
+                // The caster function is set by `boxed_type_to_trait!`,
+                // and can only be of this type.
+                .downcast_ref::<fn(Box<dyn Any>) -> Box<T>>()
+                .unwrap())(r)
+        })
+}
+
+#[doc(hidden)]
+/// Information to cast from a boxed Rust type to a boxed trait object.
+pub struct BoxedTraitCasterInfo {
+    /// The type from which we cast.
+    pub from: TypeId,
+    /// The trait to which we cast.
+    pub to: TypeId,
+    /// The cast function pointer.
+    pub caster: &'static (dyn Any + Sync + Send),
+}
+
+#[cfg(not(target_family = "wasm"))]
+pub mod boxed_statics {
+    use super::*;
+
+    #[::pliron::linkme::distributed_slice]
+    pub static BOXED_TRAIT_CASTERS: [BoxedTraitCasterInfo] = [..];
+
+    pub fn get_boxed_trait_casters() -> impl Iterator<Item = &'static BoxedTraitCasterInfo> {
+        BOXED_TRAIT_CASTERS.iter()
+    }
+}
+
+#[cfg(target_family = "wasm")]
+pub mod boxed_statics {
+    use super::*;
+
+    ::pliron::inventory::collect!(&'static BoxedTraitCasterInfo);
+
+    pub fn get_boxed_trait_casters() -> impl Iterator<Item = &'static &'static BoxedTraitCasterInfo>
+    {
+        ::pliron::inventory::iter::<&'static BoxedTraitCasterInfo>()
+    }
+}
+
+pub use boxed_statics::*;
+#[doc(hidden)]
+/// A map of all the boxed trait casters, indexed by the type_id of the object
+/// and the type_id of the trait to cast to. The map's values are
+/// the cast function pointers. This is used to avoid having to search
+/// through the distributed slice every time we want to cast an object.
+static BOXED_TRAIT_CASTERS_MAP: LazyLock<HMap<(TypeId, TypeId), &'static (dyn Any + Sync + Send)>> =
+    LazyLock::new(|| {
+        get_boxed_trait_casters()
+            .map(|lazy| ((lazy.from, lazy.to), lazy.caster))
+            .collect()
+    });
+
+/// Specify that a boxed type may be casted to a boxed `dyn Trait` object.
+/// Use [boxed_any_to_trait] for the actual cast.
+/// Example:
+/// ```
+/// # use pliron::{boxed_type_to_trait, utils::trait_cast::boxed_any_to_trait};
+/// # use pliron::alloc::boxed::Box;
+/// # use core::any::Any;
+/// trait Trait {}
+/// struct S1;
+/// impl Trait for S1 {}
+/// boxed_type_to_trait!(S1, Trait);
+///
+/// let s1: Box<dyn Any> = Box::new(S1);
+/// boxed_any_to_trait::<dyn Trait>(s1).expect("Expected S1 to implement Trait");
+///
+/// struct S2;
+/// let s2: Box<dyn Any> = Box::new(S2);
+/// assert!(
+///     boxed_any_to_trait::<dyn Trait>(s2).is_none(),
+///     "S2 does not implement Trait"
+/// );
+/// ```
+#[macro_export]
+macro_rules! boxed_type_to_trait {
+    ($ty_name:ty, $to_trait_name:path) => {
+        // The rust way to do an anonymous module.
+        const _: () = {
+            #[cfg_attr(
+                not(target_family = "wasm"),
+                ::pliron::linkme::distributed_slice
+                    ($crate::utils::trait_cast::BOXED_TRAIT_CASTERS), linkme(crate = ::pliron::linkme)
+            )]
+            static BOXED_CAST_TO_TRAIT: $crate::utils::trait_cast::BoxedTraitCasterInfo =
+                $crate::utils::trait_cast::BoxedTraitCasterInfo {
+                    from: core::any::TypeId::of::<$ty_name>(),
+                    to: core::any::TypeId::of::<dyn $to_trait_name>(),
+                    caster: &(boxed_cast_to_trait
+                        as fn(
+                            $crate::alloc::boxed::Box<dyn core::any::Any + 'static>,
+                        )
+                            -> $crate::alloc::boxed::Box<dyn $to_trait_name + 'static>)
+                        as &'static (dyn core::any::Any + Sync + Send),
+                };
+
+            #[cfg(target_family = "wasm")]
+            ::pliron::inventory::submit! {
+                &BOXED_CAST_TO_TRAIT
+            }
 
             fn boxed_cast_to_trait(
                 r: $crate::alloc::boxed::Box<dyn core::any::Any + 'static>,
             ) -> $crate::alloc::boxed::Box<dyn $to_trait_name + 'static> {
                 // This function is only called when the type of `r` is `$ty_name`,
                 // so the downcast must succeed. A failure indicates an internal bug
-                // in `type_to_trait!` or `boxed_any_to_trait`, not their usage.
+                // in `boxed_type_to_trait!` or `boxed_any_to_trait`, not their usage.
                 r.downcast::<$ty_name>().unwrap() as $crate::alloc::boxed::Box<dyn $to_trait_name>
             }
         };

--- a/src/utils/trait_cast.rs
+++ b/src/utils/trait_cast.rs
@@ -10,6 +10,8 @@
 
 use core::any::{Any, TypeId};
 
+use alloc::boxed::Box;
+
 use crate::{std_deps::sync::LazyLock, utils::table::HMap};
 
 /// Cast a [dyn Any](Any) object to a `dyn Trait` object for any
@@ -19,6 +21,7 @@ use crate::{std_deps::sync::LazyLock, utils::table::HMap};
 /// To cast from `dyn Trait1` to `dyn Trait2` (when the underlying type implements both),
 /// the user may use [downcast_rs] to easily upcast from `dyn Trait1` to [Any],
 /// and then use [any_to_trait] to cast to `dyn Trait2`.
+///
 /// Example:
 /// ```
 /// # use pliron::{type_to_trait, utils::trait_cast::any_to_trait};
@@ -47,12 +50,54 @@ use crate::{std_deps::sync::LazyLock, utils::table::HMap};
 pub fn any_to_trait<T: ?Sized + 'static>(r: &dyn Any) -> Option<&T> {
     TRAIT_CASTERS_MAP
         .get(&(r.type_id(), TypeId::of::<T>()))
-        .map(|caster| {
-            ((**caster)
+        .map(|info| {
+            (*info
+                .caster
                 // The caster function is set by `type_to_trait!`, and can only be of this type.
                 .downcast_ref::<for<'a> fn(&'a (dyn Any + 'static)) -> &'a T>()
                 .unwrap())(r)
         })
+}
+
+/// Cast a `Box<dyn Any>` object to a `Box<dyn Trait>` for any
+/// trait that the contained (in [Any]) type implements, and for which
+/// [type_to_trait](crate::type_to_trait) has been specified.
+///
+/// To cast from `Box<dyn Trait1>` to `Box<dyn Trait2>` (when the underlying type implements
+/// both), the user may use [downcast_rs] to easily upcast from `Box<dyn Trait1>` to
+/// `Box<dyn Any>`, and then use [boxed_any_to_trait] to cast to `Box<dyn Trait2>`.
+///
+/// Example:
+/// ```
+/// # use pliron::{type_to_trait, utils::trait_cast::boxed_any_to_trait};
+/// # use pliron::alloc::boxed::Box;
+/// # use core::any::Any;
+///
+/// trait Trait1 {}
+/// trait Trait2 {}
+///
+/// struct S;
+/// impl Trait1 for S {}
+/// impl Trait2 for S {}
+///
+/// type_to_trait!(S, Trait2);
+///
+/// let s1: Box<dyn Any> = Box::new(S);
+/// boxed_any_to_trait::<dyn Trait2>(s1).expect("Expected S to implement Trait2");
+///
+/// struct S2;
+/// let s2: Box<dyn Any> = Box::new(S2);
+/// assert!(boxed_any_to_trait::<dyn Trait2>(s2).is_none(), "S2 does not implement Trait2");
+/// ```
+pub fn boxed_any_to_trait<T: ?Sized + 'static>(r: Box<dyn Any>) -> Option<Box<T>> {
+    let key = ((*r).type_id(), TypeId::of::<T>());
+    TRAIT_CASTERS_MAP.get(&key).map(|info| {
+        (*info
+            .box_caster
+            // The caster function is set by `type_to_trait!`, and can only be of this type.
+            .downcast_ref::<fn(Box<dyn Any>) -> Box<T>>()
+            .unwrap())(r)
+    })
 }
 
 /// Check if type `T` was registered to be casted to trait `I`
@@ -81,8 +126,10 @@ pub struct TraitCasterInfo {
     pub from: TypeId,
     /// The trait to which we cast.
     pub to: TypeId,
-    /// The cast function pointer.
+    /// The cast function pointer, for casting a `&dyn Any` to a `&dyn Trait`.
     pub caster: &'static (dyn Any + Sync + Send),
+    /// The cast function pointer, for casting a `Box<dyn Any>` to a `Box<dyn Trait>`.
+    pub box_caster: &'static (dyn Any + Sync + Send),
 }
 
 #[cfg(not(target_family = "wasm"))]
@@ -103,8 +150,8 @@ pub mod statics {
 
     ::pliron::inventory::collect!(&'static TraitCasterInfo);
 
-    pub fn get_trait_casters() -> impl Iterator<Item = &'static &'static TraitCasterInfo> {
-        ::pliron::inventory::iter::<&'static TraitCasterInfo>()
+    pub fn get_trait_casters() -> impl Iterator<Item = &'static TraitCasterInfo> {
+        ::pliron::inventory::iter::<&'static TraitCasterInfo>().copied()
     }
 }
 
@@ -112,13 +159,12 @@ pub use statics::*;
 
 #[doc(hidden)]
 /// A map of all the trait casters, indexed by the type_id of the object
-/// and the type_id of the trait to cast to. The map's values are
-/// the cast function pointers. This is used to avoid having to search
-/// through the distributed slice every time we want to cast an object.
-static TRAIT_CASTERS_MAP: LazyLock<HMap<(TypeId, TypeId), &'static (dyn Any + Sync + Send)>> =
+/// and the type_id of the trait to cast to. The map's values hold the
+/// cast function pointers.
+static TRAIT_CASTERS_MAP: LazyLock<HMap<(TypeId, TypeId), &'static TraitCasterInfo>> =
     LazyLock::new(|| {
         get_trait_casters()
-            .map(|lazy| ((lazy.from, lazy.to), lazy.caster))
+            .map(|info| ((info.from, info.to), info))
             .collect()
     });
 
@@ -161,6 +207,12 @@ macro_rules! type_to_trait {
                             &'a (dyn core::any::Any + 'static),
                         ) -> &'a (dyn $to_trait_name + 'static))
                         as &'static (dyn core::any::Any + Sync + Send),
+                    box_caster: &(boxed_cast_to_trait
+                        as fn(
+                            $crate::alloc::boxed::Box<dyn core::any::Any + 'static>,
+                        )
+                            -> $crate::alloc::boxed::Box<dyn $to_trait_name + 'static>)
+                        as &'static (dyn core::any::Any + Sync + Send),
                 };
 
             #[cfg(target_family = "wasm")]
@@ -175,6 +227,15 @@ macro_rules! type_to_trait {
                 // so the downcast must succeed. A failure indicates an internal bug
                 // in `type_to_trait!` or `any_to_trait`, not their usage.
                 r.downcast_ref::<$ty_name>().unwrap() as &dyn $to_trait_name
+            }
+
+            fn boxed_cast_to_trait(
+                r: $crate::alloc::boxed::Box<dyn core::any::Any + 'static>,
+            ) -> $crate::alloc::boxed::Box<dyn $to_trait_name + 'static> {
+                // This function is only called when the type of `r` is `$ty_name`,
+                // so the downcast must succeed. A failure indicates an internal bug
+                // in `type_to_trait!` or `boxed_any_to_trait`, not their usage.
+                r.downcast::<$ty_name>().unwrap() as $crate::alloc::boxed::Box<dyn $to_trait_name>
             }
         };
     };


### PR DESCRIPTION
Consequently, this also introduces
 - `boxed_any_to_trait` in `trait_cast.rs` and
 - `boxed_attr_cast`, a wrapper around the above for `Attribute`s. Without this, one would need to `dyn_clone` an existing `Box<dyn Attribute>` to pass it as an input to `ConstantOp::new`.