### PR TITLE
[pliron-llvm]: Preserve inline asm side effects

### DIFF
--- a/pliron-llvm/src/from_llvm_ir.rs
+++ b/pliron-llvm/src/from_llvm_ir.rs
@@ -61,14 +61,14 @@ use crate::{
         llvm_get_fast_math_flags, llvm_get_fcmp_predicate, llvm_get_gep_no_wrap_flags,
         llvm_get_gep_source_element_type, llvm_get_icmp_predicate, llvm_get_indices,
         llvm_get_initializer, llvm_get_inline_asm_asm_string,
-        llvm_get_inline_asm_constraint_string, llvm_get_instruction_opcode,
-        llvm_get_instruction_parent, llvm_get_int_type_width, llvm_get_linkage,
-        llvm_get_mask_value, llvm_get_module_identifier, llvm_get_nneg, llvm_get_nsw,
-        llvm_get_num_arg_operands, llvm_get_num_mask_elements, llvm_get_num_operands, llvm_get_nuw,
-        llvm_get_operand, llvm_get_ordering, llvm_get_param_types, llvm_get_pointer_address_space,
-        llvm_get_return_type, llvm_get_struct_element_types, llvm_get_struct_name,
-        llvm_get_switch_case_value, llvm_get_type_kind, llvm_get_value_kind, llvm_get_value_name,
-        llvm_get_vector_size, llvm_get_volatile, llvm_global_get_value_type,
+        llvm_get_inline_asm_constraint_string, llvm_get_inline_asm_has_side_effects,
+        llvm_get_instruction_opcode, llvm_get_instruction_parent, llvm_get_int_type_width,
+        llvm_get_linkage, llvm_get_mask_value, llvm_get_module_identifier, llvm_get_nneg,
+        llvm_get_nsw, llvm_get_num_arg_operands, llvm_get_num_mask_elements, llvm_get_num_operands,
+        llvm_get_nuw, llvm_get_operand, llvm_get_ordering, llvm_get_param_types,
+        llvm_get_pointer_address_space, llvm_get_return_type, llvm_get_struct_element_types,
+        llvm_get_struct_name, llvm_get_switch_case_value, llvm_get_type_kind, llvm_get_value_kind,
+        llvm_get_value_name, llvm_get_vector_size, llvm_get_volatile, llvm_global_get_value_type,
         llvm_instruction_get_all_metadata_other_than_debug_loc, llvm_is_a, llvm_is_declaration,
         llvm_is_function_type_var_arg, llvm_is_global_constant, llvm_is_opaque_struct,
         llvm_is_packed_struct, llvm_lookup_intrinsic_id, llvm_print_type_to_string,
@@ -1071,11 +1071,19 @@ fn convert_call(
     if llvm_get_value_kind(callee) == LLVMValueKind::LLVMInlineAsmValueKind {
         let asm = llvm_get_inline_asm_asm_string(callee);
         let constraints = llvm_get_inline_asm_constraint_string(callee);
+        let side_effects = llvm_get_inline_asm_has_side_effects(callee);
         let result_ty = convert_type(ctx, cctx, llvm_type_of(inst))?;
-        // `convergent` is a call-site attribute, not recoverable through LLVM-C here.
-        return Ok(
-            InlineAsmOp::new(ctx, result_ty, args, &asm, &constraints, false).get_operation(),
-        );
+        // `convergent` is a call-site attribute, not recovered here.
+        return Ok(InlineAsmOp::new_with_side_effects(
+            ctx,
+            result_ty,
+            args,
+            &asm,
+            &constraints,
+            false,
+            side_effects,
+        )
+        .get_operation());
     }
 
     enum Callee {

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -2073,8 +2073,9 @@ impl AtomicStoreOp {
 }
 
 /// Equivalent to LLVM's inline assembly call. The template and constraint
-/// strings follow LLVM's inline-asm syntax; `convergent` marks asm that must
-/// not be reordered across divergent control flow (e.g. warp-synchronous PTX).
+/// strings follow LLVM's inline-asm syntax; `side_effects` marks asm that may
+/// have effects beyond its operands, and `convergent` marks asm that must not be
+/// reordered across divergent control flow (e.g. warp-synchronous PTX).
 ///
 /// ### Operands
 /// | operand | description |
@@ -2087,11 +2088,12 @@ impl AtomicStoreOp {
 /// | `res` | the asm result (a void type when there is none) |
 #[pliron_op(
     name = "llvm.inline_asm",
-    format = "attr($llvm_inline_asm_template, $StringAttr) `, ` attr($llvm_inline_asm_constraints, $StringAttr) ` convergent = ` attr($llvm_inline_asm_convergent, $BoolAttr) ` (` operands(CharSpace(`,`)) `) : ` type($0)",
+    format = "attr($llvm_inline_asm_template, $StringAttr) `, ` attr($llvm_inline_asm_constraints, $StringAttr) ` side_effects = ` attr($llvm_inline_asm_side_effects, $BoolAttr) ` convergent = ` attr($llvm_inline_asm_convergent, $BoolAttr) ` (` operands(CharSpace(`,`)) `) : ` type($0)",
     interfaces = [OneResultInterface],
     attributes = (
         llvm_inline_asm_template: StringAttr,
         llvm_inline_asm_constraints: StringAttr,
+        llvm_inline_asm_side_effects: BoolAttr,
         llvm_inline_asm_convergent: BoolAttr
     ),
     verifier = "succ"
@@ -2100,7 +2102,8 @@ pub struct InlineAsmOp;
 
 impl InlineAsmOp {
     /// Create a new [InlineAsmOp]. Use a void result type for asm with no
-    /// result value.
+    /// result value. Inline asm is side-effecting by default for backwards
+    /// compatibility and as the conservative choice.
     pub fn new(
         ctx: &mut Context,
         result_ty: TypeHandle,
@@ -2108,6 +2111,27 @@ impl InlineAsmOp {
         asm_template: &str,
         constraints: &str,
         convergent: bool,
+    ) -> Self {
+        Self::new_with_side_effects(
+            ctx,
+            result_ty,
+            inputs,
+            asm_template,
+            constraints,
+            convergent,
+            true,
+        )
+    }
+
+    /// Create a new [InlineAsmOp] with an explicit side-effects flag.
+    pub fn new_with_side_effects(
+        ctx: &mut Context,
+        result_ty: TypeHandle,
+        inputs: Vec<Value>,
+        asm_template: &str,
+        constraints: &str,
+        convergent: bool,
+        side_effects: bool,
     ) -> Self {
         let op = Operation::new(
             ctx,
@@ -2120,6 +2144,7 @@ impl InlineAsmOp {
         let op = InlineAsmOp { op };
         op.set_attr_llvm_inline_asm_template(ctx, StringAttr::new(asm_template.to_string()));
         op.set_attr_llvm_inline_asm_constraints(ctx, StringAttr::new(constraints.to_string()));
+        op.set_attr_llvm_inline_asm_side_effects(ctx, BoolAttr::new(side_effects));
         op.set_attr_llvm_inline_asm_convergent(ctx, BoolAttr::new(convergent));
         op
     }

--- a/pliron-llvm/src/to_llvm_ir.rs
+++ b/pliron-llvm/src/to_llvm_ir.rs
@@ -1077,8 +1077,11 @@ impl ToLLVMValue for InlineAsmOp {
                 .expect("inline asm missing constraints"))
             .clone(),
         );
-        // `has_side_effects` is set unconditionally: this op does not model a
-        // side-effects flag, and side-effecting asm is the safe default.
+        let side_effects = bool::from(
+            self.get_attr_llvm_inline_asm_side_effects(ctx)
+                .expect("inline asm missing side-effects flag")
+                .clone(),
+        );
         // NOTE: the op's `llvm_inline_asm_convergent` attribute is not applied here.
         // `convergent` is an LLVM call-site attribute (not part of the inline-asm
         // value), so converting to LLVM IR drops the convergent flag.
@@ -1086,7 +1089,7 @@ impl ToLLVMValue for InlineAsmOp {
             fn_ty,
             &asm,
             &constraints,
-            true,
+            side_effects,
             false,
             LLVMInlineAsmDialect::LLVMInlineAsmDialectATT,
             false,

--- a/pliron-llvm/tests/ir_expect.rs
+++ b/pliron-llvm/tests/ir_expect.rs
@@ -355,6 +355,41 @@ fn llvm_ir_instruction_flags_roundtrip() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn inline_asm_side_effects_roundtrip() -> Result<()> {
+    init_env_logger_for_tests!();
+    let input = r#"
+        define void @asm_side_effects() {
+        entry:
+          call void asm sideeffect "nop", ""()
+          call void asm "nop", ""()
+          ret void
+        }
+    "#;
+
+    let llvm_ctx = LLVMContext::default();
+    let ctx = &mut Context::new();
+    let module_op = common::parse_llvm_ir_verify(ctx, &llvm_ctx, input, "inline_asm_side_effects")?;
+
+    // Exercise the pliron printer/parser as part of the round trip and verify that
+    // the two LLVM inline-asm side-effect states remain distinct in the dialect.
+    let (printed, reparsed) = common::print_parse_verify(ctx, module_op)?;
+    assert!(printed.contains("side_effects = true"), "{printed}");
+    assert!(printed.contains("side_effects = false"), "{printed}");
+
+    let out_llvm_ctx = LLVMContext::default();
+    let out_mod = common::to_llvm_ir_verify(ctx, &out_llvm_ctx, reparsed)?;
+    let out = out_mod.to_string();
+    assert_eq!(out.matches("asm sideeffect").count(), 1, "{out}");
+    assert!(
+        out.contains("call void asm sideeffect \"nop\", \"\"()"),
+        "{out}"
+    );
+    assert!(out.contains("call void asm \"nop\", \"\"()"), "{out}");
+
+    Ok(())
+}
+
 /// Combinations of `struct` types
 #[test]
 fn llvm_ir_struct_combinations_roundtrip() -> Result<()> {


### PR DESCRIPTION
## Summary

Preserve LLVM inline-asm `sideeffect` semantics when converting between LLVM IR and the Pliron LLVM dialect.

Previously, `InlineAsmOp` did not model the LLVM inline-asm side-effects flag. As a result:

* LLVM -> Pliron conversion dropped the flag.
* Pliron -> LLVM conversion always emitted inline asm with `has_side_effects = true`.

This change models the flag explicitly and preserves it across round trips.

## Changes

* Add `llvm_inline_asm_side_effects: BoolAttr` to `InlineAsmOp`.
* Preserve the existing `InlineAsmOp::new(...)` behavior by defaulting side effects to `true`.
* Add `InlineAsmOp::new_with_side_effects(...)` for callers that need to specify the flag explicitly.
* Recover the flag during LLVM import using `LLVMGetInlineAsmHasSideEffects`.
* Use the stored flag when constructing LLVM inline asm instead of unconditionally passing `true`.
* Add an LLVM -> Pliron -> textual IR -> LLVM round-trip test covering both side-effecting and non-side-effecting inline asm.

`convergent` handling is intentionally left unchanged. It is an LLVM call-site attribute and will be addressed separately.

## Testing

The following checks pass:

```text
cargo fmt --check

cargo test -p pliron-llvm \
  --test ir_expect \
  inline_asm_side_effects_roundtrip \
  -- --exact

cargo clippy -p pliron-llvm --all-targets -- -D warnings

RUSTFLAGS="-D warnings" cargo test -p pliron-llvm

cargo clippy -p pliron-llvm \
  --all-targets \
  --no-default-features \
  -- -D warnings

RUSTFLAGS="-D warnings" \
cargo test -p pliron-llvm \
  --no-default-features

./pre-ci.sh
```

The new round-trip test verifies that exactly one of two inline-asm calls retains LLVM's `sideeffect` marker, while the other remains non-side-effecting.

## Checklist
- [x] I have read [CONTRIBUTING.md](../blob/HEAD/CONTRIBUTING.md).
- [x] A human is involved in writing this PR description and will handle review interactions, per our [AI tool policy](../blob/HEAD/CONTRIBUTING.md).
- [x] I understand every part of this change (including any AI-generated code) and can explain the reasoning behind it.
- [x] Intrusive / large changes were discussed on Discord before this PR.
- [x] `pre-ci.sh` passes locally.

