### PR TITLE
[pliron-llvm]: Preserve inline asm convergent attribute

### DIFF
--- a/pliron-llvm/src/from_llvm_ir.rs
+++ b/pliron-llvm/src/from_llvm_ir.rs
@@ -50,25 +50,25 @@ use crate::{
     },
     llvm_sys::core::{
         LLVMBasicBlock, LLVMModule, LLVMType, LLVMValue, basic_block_iter, function_iter,
-        global_iter, incoming_iter, instruction_iter, llvm_can_value_use_fast_math_flags,
-        llvm_const_int_get_zext_value, llvm_const_real_get_double, llvm_count_struct_element_types,
-        llvm_get_aggregate_element, llvm_get_alignment, llvm_get_allocated_type,
-        llvm_get_array_length2, llvm_get_as_string, llvm_get_atomic_rmw_bin_op,
-        llvm_get_atomic_sync_scope_id, llvm_get_basic_block_name, llvm_get_basic_block_terminator,
-        llvm_get_block_address_basic_block, llvm_get_block_address_function,
-        llvm_get_called_function_type, llvm_get_called_value, llvm_get_cmpxchg_failure_ordering,
-        llvm_get_cmpxchg_success_ordering, llvm_get_const_opcode, llvm_get_element_type,
-        llvm_get_fast_math_flags, llvm_get_fcmp_predicate, llvm_get_gep_no_wrap_flags,
-        llvm_get_gep_source_element_type, llvm_get_icmp_predicate, llvm_get_indices,
-        llvm_get_initializer, llvm_get_inline_asm_asm_string,
-        llvm_get_inline_asm_constraint_string, llvm_get_instruction_opcode,
-        llvm_get_instruction_parent, llvm_get_int_type_width, llvm_get_linkage,
-        llvm_get_mask_value, llvm_get_module_identifier, llvm_get_nneg, llvm_get_nsw,
-        llvm_get_num_arg_operands, llvm_get_num_mask_elements, llvm_get_num_operands, llvm_get_nuw,
-        llvm_get_operand, llvm_get_ordering, llvm_get_param_types, llvm_get_pointer_address_space,
-        llvm_get_return_type, llvm_get_struct_element_types, llvm_get_struct_name,
-        llvm_get_switch_case_value, llvm_get_type_kind, llvm_get_value_kind, llvm_get_value_name,
-        llvm_get_vector_size, llvm_get_volatile, llvm_global_get_value_type,
+        global_iter, incoming_iter, instruction_iter, llvm_call_site_has_enum_attribute,
+        llvm_can_value_use_fast_math_flags, llvm_const_int_get_zext_value,
+        llvm_const_real_get_double, llvm_count_struct_element_types, llvm_get_aggregate_element,
+        llvm_get_alignment, llvm_get_allocated_type, llvm_get_array_length2, llvm_get_as_string,
+        llvm_get_atomic_rmw_bin_op, llvm_get_atomic_sync_scope_id, llvm_get_basic_block_name,
+        llvm_get_basic_block_terminator, llvm_get_block_address_basic_block,
+        llvm_get_block_address_function, llvm_get_called_function_type, llvm_get_called_value,
+        llvm_get_cmpxchg_failure_ordering, llvm_get_cmpxchg_success_ordering,
+        llvm_get_const_opcode, llvm_get_element_type, llvm_get_fast_math_flags,
+        llvm_get_fcmp_predicate, llvm_get_gep_no_wrap_flags, llvm_get_gep_source_element_type,
+        llvm_get_icmp_predicate, llvm_get_indices, llvm_get_initializer,
+        llvm_get_inline_asm_asm_string, llvm_get_inline_asm_constraint_string,
+        llvm_get_instruction_opcode, llvm_get_instruction_parent, llvm_get_int_type_width,
+        llvm_get_linkage, llvm_get_mask_value, llvm_get_module_identifier, llvm_get_nneg,
+        llvm_get_nsw, llvm_get_num_arg_operands, llvm_get_num_mask_elements, llvm_get_num_operands,
+        llvm_get_nuw, llvm_get_operand, llvm_get_ordering, llvm_get_param_types,
+        llvm_get_pointer_address_space, llvm_get_return_type, llvm_get_struct_element_types,
+        llvm_get_struct_name, llvm_get_switch_case_value, llvm_get_type_kind, llvm_get_value_kind,
+        llvm_get_value_name, llvm_get_vector_size, llvm_get_volatile, llvm_global_get_value_type,
         llvm_instruction_get_all_metadata_other_than_debug_loc, llvm_is_a, llvm_is_declaration,
         llvm_is_function_type_var_arg, llvm_is_global_constant, llvm_is_opaque_struct,
         llvm_is_packed_struct, llvm_lookup_intrinsic_id, llvm_print_type_to_string,
@@ -1072,9 +1072,9 @@ fn convert_call(
         let asm = llvm_get_inline_asm_asm_string(callee);
         let constraints = llvm_get_inline_asm_constraint_string(callee);
         let result_ty = convert_type(ctx, cctx, llvm_type_of(inst))?;
-        // `convergent` is a call-site attribute, not recoverable through LLVM-C here.
+        let convergent = llvm_call_site_has_enum_attribute(inst, "convergent");
         return Ok(
-            InlineAsmOp::new(ctx, result_ty, args, &asm, &constraints, false).get_operation(),
+            InlineAsmOp::new(ctx, result_ty, args, &asm, &constraints, convergent).get_operation(),
         );
     }
 

--- a/pliron-llvm/src/llvm_sys/core.rs
+++ b/pliron-llvm/src/llvm_sys/core.rs
@@ -10,15 +10,16 @@ use std::{
 };
 
 use llvm_sys::{
-    LLVMAtomicOrdering, LLVMAtomicRMWBinOp, LLVMFastMathAllowContract, LLVMFastMathAllowReassoc,
-    LLVMFastMathAllowReciprocal, LLVMFastMathApproxFunc, LLVMFastMathFlags, LLVMFastMathNoInfs,
-    LLVMFastMathNoNaNs, LLVMFastMathNoSignedZeros, LLVMFastMathNone, LLVMGEPFlagInBounds,
-    LLVMGEPFlagNUSW, LLVMGEPFlagNUW, LLVMGEPNoWrapFlags, LLVMInlineAsmDialect, LLVMIntPredicate,
-    LLVMLinkage, LLVMOpcode, LLVMRealPredicate, LLVMTypeKind, LLVMValueKind,
+    LLVMAtomicOrdering, LLVMAtomicRMWBinOp, LLVMAttributeFunctionIndex, LLVMFastMathAllowContract,
+    LLVMFastMathAllowReassoc, LLVMFastMathAllowReciprocal, LLVMFastMathApproxFunc,
+    LLVMFastMathFlags, LLVMFastMathNoInfs, LLVMFastMathNoNaNs, LLVMFastMathNoSignedZeros,
+    LLVMFastMathNone, LLVMGEPFlagInBounds, LLVMGEPFlagNUSW, LLVMGEPFlagNUW, LLVMGEPNoWrapFlags,
+    LLVMInlineAsmDialect, LLVMIntPredicate, LLVMLinkage, LLVMOpcode, LLVMRealPredicate,
+    LLVMTypeKind, LLVMValueKind,
     analysis::LLVMVerifyModule,
     bit_writer::LLVMWriteBitcodeToFile,
     core::{
-        LLVMAddCase, LLVMAddDestination, LLVMAddFunction, LLVMAddGlobal,
+        LLVMAddCallSiteAttribute, LLVMAddCase, LLVMAddDestination, LLVMAddFunction, LLVMAddGlobal,
         LLVMAddGlobalInAddressSpace, LLVMAddIncoming, LLVMAddNamedMetadataOperand,
         LLVMAppendBasicBlockInContext, LLVMArrayType2, LLVMBasicBlockAsValue, LLVMBlockAddress,
         LLVMBuildAShr, LLVMBuildAdd, LLVMBuildAddrSpaceCast, LLVMBuildAnd, LLVMBuildArrayAlloca,
@@ -38,22 +39,23 @@ use llvm_sys::{
         LLVMConstNamedStruct, LLVMConstNull, LLVMConstReal, LLVMConstRealGetDouble,
         LLVMConstStringInContext2, LLVMConstVector, LLVMContextCreate, LLVMContextDispose,
         LLVMCountIncoming, LLVMCountParamTypes, LLVMCountParams, LLVMCountStructElementTypes,
-        LLVMCreateBuilderInContext, LLVMCreateMemoryBufferWithContentsOfFile,
-        LLVMCreateMemoryBufferWithMemoryRangeCopy, LLVMDeleteFunction, LLVMDeleteGlobal,
-        LLVMDisposeMemoryBuffer, LLVMDisposeMessage, LLVMDisposeModule,
-        LLVMDisposeValueMetadataEntries, LLVMDoubleTypeInContext, LLVMDumpModule, LLVMDumpType,
-        LLVMDumpValue, LLVMFloatTypeInContext, LLVMFunctionType, LLVMGEPGetNoWrapFlags,
-        LLVMGetAggregateElement, LLVMGetAlignment, LLVMGetAllocatedType, LLVMGetArrayLength2,
-        LLVMGetAsString, LLVMGetAtomicRMWBinOp, LLVMGetAtomicSyncScopeID, LLVMGetBasicBlockName,
-        LLVMGetBasicBlockParent, LLVMGetBasicBlockTerminator, LLVMGetBlockAddressBasicBlock,
-        LLVMGetBlockAddressFunction, LLVMGetCalledFunctionType, LLVMGetCalledValue,
-        LLVMGetCmpXchgFailureOrdering, LLVMGetCmpXchgSuccessOrdering, LLVMGetConstOpcode,
-        LLVMGetDataLayoutStr, LLVMGetElementType, LLVMGetFCmpPredicate, LLVMGetFastMathFlags,
-        LLVMGetFirstBasicBlock, LLVMGetFirstFunction, LLVMGetFirstGlobal, LLVMGetFirstInstruction,
-        LLVMGetFirstNamedMetadata, LLVMGetFirstParam, LLVMGetGEPSourceElementType,
-        LLVMGetICmpPredicate, LLVMGetIncomingBlock, LLVMGetIncomingValue, LLVMGetIndices,
-        LLVMGetInitializer, LLVMGetInlineAsm, LLVMGetInlineAsmAsmString,
-        LLVMGetInlineAsmConstraintString, LLVMGetInlineAsmFunctionType,
+        LLVMCreateBuilderInContext, LLVMCreateEnumAttribute,
+        LLVMCreateMemoryBufferWithContentsOfFile, LLVMCreateMemoryBufferWithMemoryRangeCopy,
+        LLVMDeleteFunction, LLVMDeleteGlobal, LLVMDisposeMemoryBuffer, LLVMDisposeMessage,
+        LLVMDisposeModule, LLVMDisposeValueMetadataEntries, LLVMDoubleTypeInContext,
+        LLVMDumpModule, LLVMDumpType, LLVMDumpValue, LLVMFloatTypeInContext, LLVMFunctionType,
+        LLVMGEPGetNoWrapFlags, LLVMGetAggregateElement, LLVMGetAlignment, LLVMGetAllocatedType,
+        LLVMGetArrayLength2, LLVMGetAsString, LLVMGetAtomicRMWBinOp, LLVMGetAtomicSyncScopeID,
+        LLVMGetBasicBlockName, LLVMGetBasicBlockParent, LLVMGetBasicBlockTerminator,
+        LLVMGetBlockAddressBasicBlock, LLVMGetBlockAddressFunction, LLVMGetCallSiteEnumAttribute,
+        LLVMGetCalledFunctionType, LLVMGetCalledValue, LLVMGetCmpXchgFailureOrdering,
+        LLVMGetCmpXchgSuccessOrdering, LLVMGetConstOpcode, LLVMGetDataLayoutStr,
+        LLVMGetElementType, LLVMGetEnumAttributeKindForName, LLVMGetFCmpPredicate,
+        LLVMGetFastMathFlags, LLVMGetFirstBasicBlock, LLVMGetFirstFunction, LLVMGetFirstGlobal,
+        LLVMGetFirstInstruction, LLVMGetFirstNamedMetadata, LLVMGetFirstParam,
+        LLVMGetGEPSourceElementType, LLVMGetICmpPredicate, LLVMGetIncomingBlock,
+        LLVMGetIncomingValue, LLVMGetIndices, LLVMGetInitializer, LLVMGetInlineAsm,
+        LLVMGetInlineAsmAsmString, LLVMGetInlineAsmConstraintString, LLVMGetInlineAsmFunctionType,
         LLVMGetInlineAsmHasSideEffects, LLVMGetInsertBlock, LLVMGetInstructionOpcode,
         LLVMGetInstructionParent, LLVMGetIntTypeWidth, LLVMGetIntrinsicDeclaration,
         LLVMGetLastFunction, LLVMGetLastGlobal, LLVMGetLinkage, LLVMGetMDKindIDInContext,
@@ -2810,6 +2812,27 @@ pub fn llvm_get_num_arg_operands(inst: LLVMValue) -> u32 {
 pub fn llvm_get_called_function_type(inst: LLVMValue) -> LLVMType {
     assert!(llvm_is_a::call_inst(inst) || llvm_is_a::invoke_inst(inst));
     unsafe { LLVMGetCalledFunctionType(inst.into()).into() }
+}
+
+/// Return whether a call site has the named enum attribute.
+pub fn llvm_call_site_has_enum_attribute(inst: LLVMValue, name: &str) -> bool {
+    assert!(llvm_is_a::call_inst(inst) || llvm_is_a::invoke_inst(inst));
+    let kind_id = unsafe { LLVMGetEnumAttributeKindForName(name.as_ptr().cast(), name.len()) };
+    if kind_id == 0 {
+        return false;
+    }
+    let attr =
+        unsafe { LLVMGetCallSiteEnumAttribute(inst.into(), LLVMAttributeFunctionIndex, kind_id) };
+    !attr.is_null()
+}
+
+/// Add a named enum attribute to a call site.
+pub fn llvm_add_call_site_enum_attribute(context: &LLVMContext, inst: LLVMValue, name: &str) {
+    assert!(llvm_is_a::call_inst(inst) || llvm_is_a::invoke_inst(inst));
+    let kind_id = unsafe { LLVMGetEnumAttributeKindForName(name.as_ptr().cast(), name.len()) };
+    assert_ne!(kind_id, 0, "Unknown LLVM enum attribute: {name}");
+    let attr = unsafe { LLVMCreateEnumAttribute(context.inner_ref(), kind_id, 0) };
+    unsafe { LLVMAddCallSiteAttribute(inst.into(), LLVMAttributeFunctionIndex, attr) };
 }
 
 /// LLVMGetNUW

--- a/pliron-llvm/src/to_llvm_ir.rs
+++ b/pliron-llvm/src/to_llvm_ir.rs
@@ -52,29 +52,30 @@ use crate::{
     },
     llvm_sys::core::{
         LLVMBasicBlock, LLVMBuilder, LLVMContext, LLVMModule, LLVMType, LLVMValue,
-        instruction_iter, llvm_add_case, llvm_add_destination, llvm_add_function,
-        llvm_add_global_in_address_space, llvm_add_incoming, llvm_append_basic_block_in_context,
-        llvm_array_type2, llvm_block_address, llvm_build_add, llvm_build_addrspacecast,
-        llvm_build_and, llvm_build_array_alloca, llvm_build_ashr, llvm_build_atomic_cmpxchg,
-        llvm_build_atomic_rmw, llvm_build_bitcast, llvm_build_br, llvm_build_call2,
-        llvm_build_cond_br, llvm_build_extract_element, llvm_build_extract_value, llvm_build_fadd,
-        llvm_build_fcmp, llvm_build_fdiv, llvm_build_fence, llvm_build_fmul, llvm_build_fneg,
-        llvm_build_fpext, llvm_build_fptosi, llvm_build_fptoui, llvm_build_fptrunc,
-        llvm_build_freeze, llvm_build_frem, llvm_build_fsub, llvm_build_gep_with_no_wrap_flags,
-        llvm_build_icmp, llvm_build_indirect_br, llvm_build_insert_element,
-        llvm_build_insert_value, llvm_build_int_to_ptr, llvm_build_load2, llvm_build_lshr,
-        llvm_build_mul, llvm_build_or, llvm_build_phi, llvm_build_ptr_to_int, llvm_build_ret,
-        llvm_build_ret_void, llvm_build_sdiv, llvm_build_select, llvm_build_sext, llvm_build_shl,
-        llvm_build_shuffle_vector, llvm_build_sitofp, llvm_build_srem, llvm_build_store,
-        llvm_build_sub, llvm_build_switch, llvm_build_trunc, llvm_build_udiv, llvm_build_uitofp,
-        llvm_build_unreachable, llvm_build_urem, llvm_build_va_arg, llvm_build_xor,
-        llvm_build_zext, llvm_can_value_use_fast_math_flags, llvm_clear_insertion_position,
-        llvm_const_array, llvm_const_int, llvm_const_null, llvm_const_real,
-        llvm_const_string_in_context, llvm_const_struct, llvm_const_vector, llvm_delete_global,
-        llvm_double_type_in_context, llvm_float_type_in_context, llvm_function_type,
-        llvm_get_inline_asm, llvm_get_named_function, llvm_get_param,
-        llvm_get_pointer_address_space, llvm_get_poison, llvm_get_sync_scope_id, llvm_get_undef,
-        llvm_half_type_in_context, llvm_int_type_in_context, llvm_is_a, llvm_lookup_intrinsic_id,
+        instruction_iter, llvm_add_call_site_enum_attribute, llvm_add_case, llvm_add_destination,
+        llvm_add_function, llvm_add_global_in_address_space, llvm_add_incoming,
+        llvm_append_basic_block_in_context, llvm_array_type2, llvm_block_address, llvm_build_add,
+        llvm_build_addrspacecast, llvm_build_and, llvm_build_array_alloca, llvm_build_ashr,
+        llvm_build_atomic_cmpxchg, llvm_build_atomic_rmw, llvm_build_bitcast, llvm_build_br,
+        llvm_build_call2, llvm_build_cond_br, llvm_build_extract_element, llvm_build_extract_value,
+        llvm_build_fadd, llvm_build_fcmp, llvm_build_fdiv, llvm_build_fence, llvm_build_fmul,
+        llvm_build_fneg, llvm_build_fpext, llvm_build_fptosi, llvm_build_fptoui,
+        llvm_build_fptrunc, llvm_build_freeze, llvm_build_frem, llvm_build_fsub,
+        llvm_build_gep_with_no_wrap_flags, llvm_build_icmp, llvm_build_indirect_br,
+        llvm_build_insert_element, llvm_build_insert_value, llvm_build_int_to_ptr,
+        llvm_build_load2, llvm_build_lshr, llvm_build_mul, llvm_build_or, llvm_build_phi,
+        llvm_build_ptr_to_int, llvm_build_ret, llvm_build_ret_void, llvm_build_sdiv,
+        llvm_build_select, llvm_build_sext, llvm_build_shl, llvm_build_shuffle_vector,
+        llvm_build_sitofp, llvm_build_srem, llvm_build_store, llvm_build_sub, llvm_build_switch,
+        llvm_build_trunc, llvm_build_udiv, llvm_build_uitofp, llvm_build_unreachable,
+        llvm_build_urem, llvm_build_va_arg, llvm_build_xor, llvm_build_zext,
+        llvm_can_value_use_fast_math_flags, llvm_clear_insertion_position, llvm_const_array,
+        llvm_const_int, llvm_const_null, llvm_const_real, llvm_const_string_in_context,
+        llvm_const_struct, llvm_const_vector, llvm_delete_global, llvm_double_type_in_context,
+        llvm_float_type_in_context, llvm_function_type, llvm_get_inline_asm,
+        llvm_get_named_function, llvm_get_param, llvm_get_pointer_address_space, llvm_get_poison,
+        llvm_get_sync_scope_id, llvm_get_undef, llvm_half_type_in_context,
+        llvm_int_type_in_context, llvm_is_a, llvm_lookup_intrinsic_id,
         llvm_pointer_type_in_context, llvm_position_builder_at_end, llvm_replace_all_uses_with,
         llvm_scalable_vector_type, llvm_set_alignment, llvm_set_atomic_sync_scope_id,
         llvm_set_fast_math_flags, llvm_set_global_constant, llvm_set_initializer, llvm_set_linkage,
@@ -1079,9 +1080,11 @@ impl ToLLVMValue for InlineAsmOp {
         );
         // `has_side_effects` is set unconditionally: this op does not model a
         // side-effects flag, and side-effecting asm is the safe default.
-        // NOTE: the op's `llvm_inline_asm_convergent` attribute is not applied here.
-        // `convergent` is an LLVM call-site attribute (not part of the inline-asm
-        // value), so converting to LLVM IR drops the convergent flag.
+        let convergent = bool::from(
+            self.get_attr_llvm_inline_asm_convergent(ctx)
+                .expect("inline asm missing convergent flag")
+                .clone(),
+        );
         let asm_val = llvm_get_inline_asm(
             fn_ty,
             &asm,
@@ -1096,13 +1099,11 @@ impl ToLLVMValue for InlineAsmOp {
         } else {
             result_val.unique_name(ctx).to_string()
         };
-        Ok(llvm_build_call2(
-            &cctx.builder,
-            fn_ty,
-            asm_val,
-            &args,
-            &name,
-        ))
+        let call = llvm_build_call2(&cctx.builder, fn_ty, asm_val, &args, &name);
+        if convergent {
+            llvm_add_call_site_enum_attribute(llvm_ctx, call, "convergent");
+        }
+        Ok(call)
     }
 }
 

--- a/pliron-llvm/tests/ir_expect.rs
+++ b/pliron-llvm/tests/ir_expect.rs
@@ -355,6 +355,49 @@ fn llvm_ir_instruction_flags_roundtrip() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn inline_asm_convergent_roundtrip() -> Result<()> {
+    init_env_logger_for_tests!();
+    let input = r#"
+        define void @asm_convergent() {
+        entry:
+          call void asm sideeffect "nop", ""() #0
+          call void asm sideeffect "nop", ""()
+          ret void
+        }
+
+        attributes #0 = { convergent }
+    "#;
+
+    let llvm_ctx = LLVMContext::default();
+    let ctx = &mut Context::new();
+    let module_op = common::parse_llvm_ir_verify(ctx, &llvm_ctx, input, "inline_asm_convergent")?;
+
+    // Exercise the pliron printer/parser as part of the round trip and verify that
+    // the two LLVM inline-asm convergence states remain distinct in the dialect.
+    let (printed, reparsed) = common::print_parse_verify(ctx, module_op)?;
+    assert!(printed.contains("convergent = true"), "{printed}");
+    assert!(printed.contains("convergent = false"), "{printed}");
+
+    let out_llvm_ctx = LLVMContext::default();
+    let out_mod = common::to_llvm_ir_verify(ctx, &out_llvm_ctx, reparsed)?;
+    let out = out_mod.to_string();
+    let asm_calls: Vec<_> = out
+        .lines()
+        .filter(|line| line.contains("call void asm sideeffect \"nop\", \"\"()"))
+        .collect();
+    assert_eq!(asm_calls.len(), 2, "{out}");
+    assert!(asm_calls[0].contains(" #"), "{out}");
+    assert!(!asm_calls[1].contains(" #"), "{out}");
+    assert!(
+        out.lines()
+            .any(|line| line.starts_with("attributes #") && line.contains("convergent")),
+        "{out}"
+    );
+
+    Ok(())
+}
+
 /// Combinations of `struct` types
 #[test]
 fn llvm_ir_struct_combinations_roundtrip() -> Result<()> {


### PR DESCRIPTION
## Summary

Preserve LLVM inline-asm `convergent` semantics when converting between LLVM IR and the Pliron LLVM dialect.

`InlineAsmOp` already models `llvm_inline_asm_convergent`, but the LLVM bridge did not preserve it:

* LLVM -> Pliron conversion always set `convergent = false`.
* Pliron -> LLVM conversion did not emit the LLVM call-site `convergent` attribute.

This change preserves the flag across round trips.

## Changes

* Add minimal helpers for reading and writing LLVM enum call-site attributes.
* Recover the `convergent` call-site attribute when importing inline asm from LLVM IR.
* Emit the `convergent` call-site attribute when lowering a convergent `InlineAsmOp` to LLVM IR.
* Add an LLVM -> Pliron -> textual IR -> LLVM round-trip test covering both convergent and non-convergent inline asm.

`sideeffect` handling is intentionally kept separate and is addressed by #252.

## Testing

The following checks pass:

```text
cargo fmt --check

cargo test -p pliron-llvm \
  --test ir_expect \
  inline_asm_convergent_roundtrip \
  -- --exact

cargo clippy -p pliron-llvm \
  --all-targets \
  -- -D warnings

RUSTFLAGS="-D warnings" cargo test -p pliron-llvm

cargo clippy -p pliron-llvm \
  --all-targets \
  --no-default-features \
  -- -D warnings

RUSTFLAGS="-D warnings" \
cargo test -p pliron-llvm \
  --no-default-features

./pre-ci.sh
```

The round-trip test verifies that the `convergent` call-site attribute is preserved for convergent inline asm while remaining absent for non-convergent inline asm.

## Checklist
- [x] I have read [CONTRIBUTING.md](../blob/HEAD/CONTRIBUTING.md).
- [x] A human is involved in writing this PR description and will handle review interactions, per our [AI tool policy](../blob/HEAD/CONTRIBUTING.md).
- [x] I understand every part of this change (including any AI-generated code) and can explain the reasoning behind it.
- [x] Intrusive / large changes were discussed on Discord before this PR.
- [x] `pre-ci.sh` passes locally.
