### PR TITLE
Make `Box<dyn AttrInterface>` usable in place of `AttrObj`

### DIFF
--- a/pliron-derive/src/interfaces.rs
+++ b/pliron-derive/src/interfaces.rs
@@ -21,6 +21,14 @@ pub(crate) fn interface_define(
     target_marker_trait: Path,
 ) -> Result<proc_macro2::TokenStream> {
     let mut r#trait = syn::parse2::<ItemTrait>(input.into())?;
+
+    if let Some(lifetime) = r#trait.generics.lifetimes().next() {
+        return Err(syn::Error::new_spanned(
+            lifetime,
+            "An interface cannot have a lifetime parameter",
+        ));
+    }
+
     let intr_name = r#trait.ident.clone();
     let generics = r#trait.generics.clone();
     // https://github.com/kardeiz/objekt-clonable/blob/master/dyn-clonable-impl/src/lib.rs
@@ -85,6 +93,79 @@ pub(crate) fn interface_define(
     });
 
     Ok(output)
+}
+
+/// Implement common traits for `Box<dyn Interface>`.
+///
+/// These all delegate to the `Attribute` that the interface object holds.
+pub(crate) fn attr_interface_obj_traits(
+    input: proc_macro::TokenStream,
+) -> Result<proc_macro2::TokenStream> {
+    let r#trait = syn::parse2::<ItemTrait>(input.into())?;
+    let intr_name = r#trait.ident.clone();
+    let generics = r#trait.generics.clone();
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    // Only 'static lifetimes work, and that's checked for by `interface_define`.
+    let mut obj_where_clause = where_clause
+        .cloned()
+        .unwrap_or_else(|| parse_quote! { where });
+    for ty_param in generics.type_params() {
+        let ty_param = &ty_param.ident;
+        obj_where_clause
+            .predicates
+            .push(parse_quote! { #ty_param: 'static });
+    }
+
+    // Equality and hashing are on the interface object itself.
+    // `Box<dyn Interface>` gets them from the standard library's impls for `Box`.
+    Ok(quote! {
+        impl #impl_generics ::core::cmp::PartialEq for dyn #intr_name #ty_generics #obj_where_clause {
+            fn eq(&self, other: &Self) -> bool {
+                ::pliron::attribute::Attribute::eq_attr(self, other)
+            }
+        }
+
+        impl #impl_generics ::core::cmp::Eq for dyn #intr_name #ty_generics #obj_where_clause {}
+
+        impl #impl_generics ::core::hash::Hash for dyn #intr_name #ty_generics #obj_where_clause {
+            fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) {
+                ::core::hash::Hasher::write_u64(
+                    state,
+                    ::pliron::attribute::Attribute::hash_attr(self).into(),
+                );
+            }
+        }
+
+        // Printable: Call the same formatting function that `AttrObj` does.
+        impl #impl_generics ::pliron::printable::Printable
+            for ::pliron::alloc::boxed::Box<dyn #intr_name #ty_generics> #obj_where_clause
+        {
+            fn fmt(
+                &self,
+                ctx: &::pliron::context::Context,
+                state: &::pliron::printable::State,
+                f: &mut ::core::fmt::Formatter<'_>,
+            ) -> ::core::fmt::Result {
+                ::pliron::attribute::fmt_attr_obj(&**self, ctx, state, f)
+            }
+        }
+
+        // Parsable: The box parses any attribute, and rejects one that isn't of this interface.
+        impl #impl_generics ::pliron::parsable::Parsable
+            for ::pliron::alloc::boxed::Box<dyn #intr_name #ty_generics> #obj_where_clause
+        {
+            type Arg = ();
+            type Parsed = Self;
+
+            fn parse<'a>(
+                state_stream: &mut ::pliron::parsable::StateStream<'a>,
+                _arg: Self::Arg,
+            ) -> ::pliron::parsable::ParseResult<'a, Self::Parsed> {
+                ::pliron::attribute::parse_attr_interface_obj(state_stream)
+            }
+        }
+    })
 }
 
 /// Whether an interface impl must also be registered for casting boxed objects

--- a/pliron-derive/src/lib.rs
+++ b/pliron-derive/src/lib.rs
@@ -961,13 +961,21 @@ pub fn attr_interface(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let verifier_type = parse_quote! { ::pliron::attribute::AttrInterfaceVerifier };
     let target_marker_trait = parse_quote! { ::pliron::attribute::AttrInterfaceMarker };
 
-    to_token_stream(interfaces::interface_define(
-        item,
+    let define = interfaces::interface_define(
+        item.clone(),
         supertrait,
         verifier_type,
         true,
         target_marker_trait,
-    ))
+    );
+
+    // Implement common traits for `dyn Interface` that we already implement for `AttrObj`.
+    let obj_traits = interfaces::attr_interface_obj_traits(item);
+
+    to_token_stream(define.and_then(|mut output| {
+        output.extend(obj_traits?);
+        Ok(output)
+    }))
 }
 
 /// Implement [Attribute](../pliron/attribute/trait.Attribute.html) Interface for an Attribute.

--- a/pliron-llvm/src/metadata.rs
+++ b/pliron-llvm/src/metadata.rs
@@ -46,7 +46,7 @@ use alloc::{
 };
 use pliron::{
     arg_err,
-    attribute::{AttrObj, Attribute, attr_impls, verify_attr},
+    attribute::{Attribute, verify_attr},
     builtin::{
         attr_interfaces::{OutlinedAttr, TypedAttrInterface},
         ops::ModuleOp,
@@ -121,7 +121,7 @@ pub enum MdOperandAttr {
     /// A reference to another node in the module's metadata table. Printed as `#42`.
     Node(MdNodeId),
     /// LLVM's `ConstantAsMetadata` wrapping a constant value.
-    Constant(AttrObj),
+    Constant(Box<dyn TypedAttrInterface>),
 }
 
 impl Printable for MdOperandAttr {
@@ -163,7 +163,7 @@ impl Parsable for MdOperandAttr {
             token('#')
                 .with(MdNodeId::parser(()))
                 .map(MdOperandAttr::Node),
-            AttrObj::parser(()).map(MdOperandAttr::Constant),
+            <Box<dyn TypedAttrInterface>>::parser(()).map(MdOperandAttr::Constant),
         ))
         .parse_stream(state_stream)
         .into()
@@ -695,8 +695,6 @@ pub enum MetadataVerifyErr {
     NoTable,
     #[error("Metadata refers to \"{0}\", which is not a symbol of this module")]
     UndefinedSymbol(String),
-    #[error("Metadata operand {0} is not a constant")]
-    NotAConstant(String),
 }
 
 /// Ensure that symbols referred to by constant `attr` resolve in `module_op`.
@@ -731,9 +729,8 @@ fn check_symbols_resolve(
 /// Verify that
 /// - Every metadata reference in the module rooted at `module_op`
 ///   resolves to a node in the module's metadata table
-/// - Every constant operand that a metadata node holds impls
-///   [TypedAttrInterface], verifies, and refers only to symbols
-///   of the module.
+/// - Every constant that a metadata node holds verifies and refers
+///   only to symbols of the module.
 pub fn verify_metadata(ctx: &Context, module_op: ModuleOp) -> Result<()> {
     let module_op_ptr = module_op.get_operation();
     let table = get_metadata_table(ctx, module_op).unwrap_or_default();
@@ -753,13 +750,6 @@ pub fn verify_metadata(ctx: &Context, module_op: ModuleOp) -> Result<()> {
             match operand {
                 MdOperandAttr::Node(id) => check(*id, loc.clone())?,
                 MdOperandAttr::Constant(attr) => {
-                    // Only a typed attribute can be an LLVM constant.
-                    if !attr_impls::<dyn TypedAttrInterface>(&**attr) {
-                        verify_err!(
-                            loc.clone(),
-                            MetadataVerifyErr::NotAConstant(attr.disp(ctx).to_string())
-                        )?;
-                    }
                     verify_attr(&**attr, ctx).map_err(|mut err| {
                         if err.loc.is_unknown() {
                             err.set_loc(loc.clone());

--- a/pliron-llvm/src/metadata_conversions.rs
+++ b/pliron-llvm/src/metadata_conversions.rs
@@ -13,7 +13,8 @@ pub mod from_llvm_ir {
 
     use llvm_sys::debuginfo::LLVMMetadataKind;
     use pliron::{
-        builtin::ops::ModuleOp,
+        attribute::boxed_attr_cast,
+        builtin::{attr_interfaces::TypedAttrInterface, ops::ModuleOp},
         context::{Context, Ptr},
         input_error_noloc,
         operation::Operation,
@@ -304,7 +305,11 @@ pub mod from_llvm_ir {
             }
             LLVMMetadataKind::LLVMConstantAsMetadataMetadataKind => {
                 match const_llvm_value_to_attr(ctx, cctx, val)? {
-                    Some(attr) => Ok(Some(MdOperandAttr::Constant(attr))),
+                    Some(attr) => {
+                        let attr = boxed_attr_cast::<dyn TypedAttrInterface>(attr)
+                            .expect("Every constant attribute we build has a type");
+                        Ok(Some(MdOperandAttr::Constant(attr)))
+                    }
                     None => {
                         log::warn!(
                             "Dropping unsupported constant metadata operand {}",

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -47,13 +47,13 @@ use crate::{
     dialect::{Dialect, DialectName},
     dyn_clone::DynClone,
     identifier::Identifier,
-    impl_printable_for_display, input_err,
+    impl_printable_for_display, input_err, input_error,
     irfmt::{
         parsers::{attr_parser, delimited_list_parser, spaced},
         printers::iter_with_sep,
     },
     location::Located,
-    parsable::{Parsable, ParseResult, StateStream},
+    parsable::{IntoParseResult, Parsable, ParseResult, StateStream},
     printable::{self, Printable},
     result::Result,
     std_deps::sync::LazyLock,
@@ -64,13 +64,18 @@ use crate::{
         trait_cast::impls_trait_static,
     },
 };
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    vec::Vec,
+};
 use core::{
     fmt::{Debug, Display},
     hash::{Hash, Hasher},
     ops::Deref,
 };
 use downcast_rs::{Downcast, impl_downcast};
+use thiserror::Error;
 
 /// Convenience type to easily print and parse key-value pairs in an [AttributeDict].
 #[derive(Clone)]
@@ -266,6 +271,30 @@ impl Hash for AttrObj {
     }
 }
 
+/// Print [AttrId] followed by the attribute itself.
+///
+/// This is generally used through `AttrObj as Printable`,
+/// or `Box<dyn I> as Printable`.
+/// ```
+/// use pliron::{
+///     attribute::AttrObj, builtin::attributes::StringAttr, context::Context,
+///     printable::Printable,
+/// };
+/// let ctx = &Context::new();
+///
+/// let attr: AttrObj = Box::new(StringAttr::new("hello".to_string()));
+/// assert_eq!(attr.disp(ctx).to_string(), r#"builtin.string "hello""#);
+/// ```
+pub fn fmt_attr_obj(
+    attr: &dyn Attribute,
+    ctx: &Context,
+    state: &printable::State,
+    f: &mut core::fmt::Formatter<'_>,
+) -> core::fmt::Result {
+    write!(f, "{} ", attr.get_attr_id())?;
+    Printable::fmt(attr, ctx, state, f)
+}
+
 impl Printable for AttrObj {
     fn fmt(
         &self,
@@ -273,9 +302,60 @@ impl Printable for AttrObj {
         state: &printable::State,
         f: &mut core::fmt::Formatter<'_>,
     ) -> core::fmt::Result {
-        write!(f, "{} ", self.get_attr_id())?;
-        Printable::fmt(self.deref(), ctx, state, f)
+        fmt_attr_obj(self.deref(), ctx, state, f)
     }
+}
+
+#[derive(Debug, Error)]
+#[error("{provided} does not implement the attribute interface {interface}")]
+pub struct AttrInterfaceCastErr {
+    pub interface: String,
+    pub provided: String,
+}
+
+/// Parse `Box<dyn I>`.
+///
+/// This is generally used through `<Box<dyn I>>::parser` and not directly.
+/// ```
+/// use pliron::{
+///     builtin::{
+///         attr_interfaces::TypedAttrInterface,
+///         types::{IntegerType, Signedness},
+///     },
+///     context::Context,
+///     parsable::{Parsable, parse_from_str},
+/// };
+/// let ctx = &mut Context::new();
+///
+/// // `Box<dyn TypedAttrInterface>` parses through this.
+/// let parser = <Box<dyn TypedAttrInterface>>::parser(());
+/// let attr = parse_from_str(parser, ctx, "builtin.integer <42: si64>")
+///     .expect("An IntegerAttr has a type");
+/// assert_eq!(attr.get_type(ctx), IntegerType::get(ctx, 64, Signedness::Signed).into());
+///
+/// // A string carries no type, so it isn't a `TypedAttrInterface`.
+/// let parser = <Box<dyn TypedAttrInterface>>::parser(());
+/// assert!(parse_from_str(parser, ctx, r#"builtin.string "hello""#).is_err());
+/// ```
+pub fn parse_attr_interface_obj<'a, I: ?Sized + AttrInterfaceMarker + 'static>(
+    state_stream: &mut StateStream<'a>,
+) -> ParseResult<'a, Box<I>> {
+    let loc = state_stream.loc();
+    let (attr, _) = attr_parser().parse_stream(state_stream).into_result()?;
+
+    // The cast consumes the attribute, so name it for the error before casting.
+    let provided = attr.get_attr_id();
+    boxed_attr_cast::<I>(attr)
+        .ok_or_else(|| {
+            input_error!(
+                loc,
+                AttrInterfaceCastErr {
+                    interface: core::any::type_name::<I>().to_string(),
+                    provided: provided.to_string(),
+                }
+            )
+        })
+        .into_parse_result()
 }
 
 impl Parsable for AttrObj {

--- a/tests/interfaces.rs
+++ b/tests/interfaces.rs
@@ -6,11 +6,13 @@ mod common;
 use common::{ConstantOp, ReturnOp};
 use expect_test::expect;
 
+use std::hash::{DefaultHasher, Hash, Hasher};
+
 use pliron::{
-    attribute::{Attribute, attr_cast, verify_attr},
+    attribute::{AttrObj, Attribute, attr_cast, boxed_attr_cast, verify_attr},
     builtin::{
         attr_interfaces::{OutlinedAttr, PrintOnceAttr, TypedAttrInterface},
-        attributes::{IntegerAttr, StringAttr},
+        attributes::{IntegerAttr, StringAttr, TypeAttr},
         op_interfaces::{NResultsVerifyErr, OneResultInterface},
         ops::ModuleOp,
         type_interfaces::FloatTypeInterface,
@@ -355,6 +357,59 @@ impl TypedAttrInterface for MyAttr {
     }
 }
 
+/// A boxed attribute interface object behaves like an [AttrObj]: it compares, hashes,
+/// prints and parses as the attribute it holds.
+#[test]
+#[cfg_attr(target_family = "wasm", wasm_bindgen_test)]
+fn test_boxed_attr_interface_obj() {
+    let ctx = &mut Context::new();
+
+    let boxed = |s: &str| -> Box<dyn TestAttrInterfaceX> {
+        boxed_attr_cast(Box::new(StringAttr::new(s.to_string())) as AttrObj)
+            .expect("StringAttr implements TestAttrInterfaceX")
+    };
+
+    // `assert_eq` would compare the unsized `dyn` objects, so compare the boxes.
+    assert!(boxed("hello") == boxed("hello"));
+    assert!(boxed("hello") != boxed("world"));
+
+    let hash = |attr: Box<dyn TestAttrInterfaceX>| {
+        let mut hasher = DefaultHasher::new();
+        attr.hash(&mut hasher);
+        hasher.finish()
+    };
+    assert_eq!(hash(boxed("hello")), hash(boxed("hello")));
+
+    // The box prints the attribute's name, just as an `AttrObj` does, and parses
+    // that form back.
+    let printed = boxed("hello").disp(ctx).to_string();
+    assert_eq!(
+        printed,
+        (Box::new(StringAttr::new("hello".to_string())) as AttrObj)
+            .disp(ctx)
+            .to_string()
+    );
+    let parsed = parse_from_str(<Box<dyn TestAttrInterfaceX>>::parser(()), ctx, &printed)
+        .expect("the printed form must parse back");
+    assert!(parsed == boxed("hello"));
+
+    // An attribute that doesn't implement the interface is rejected.
+    let unit_ty_attr = (Box::new(TypeAttr::new(UnitType::get(ctx).into())) as AttrObj)
+        .disp(ctx)
+        .to_string();
+    let err = parse_from_str(
+        <Box<dyn TestAttrInterfaceX>>::parser(()),
+        ctx,
+        &unit_ty_attr,
+    )
+    .expect_err("TypeAttr doesn't implement TestAttrInterfaceX");
+    assert!(
+        err.to_string()
+            .contains("does not implement the attribute interface"),
+        "unexpected error: {err}"
+    );
+}
+
 static TEST_ATTR_VERIFIERS_OUTPUT: LazyLock<Mutex<String>> =
     LazyLock::new(|| Mutex::new("".into()));
 
@@ -644,6 +699,11 @@ static TEST_TYPE_VERIFIERS_OUTPUT_GENERIC: LazyLock<Mutex<String>> =
 
 #[type_interface]
 trait TestTypeInterfaceGeneric<T: Clone> {
+    /// Name of the type argument that this interface is instantiated with.
+    fn type_arg_name(&self) -> &'static str {
+        core::any::type_name::<T>()
+    }
+
     fn verify(_op: &dyn Type, _ctx: &Context) -> Result<()>
     where
         Self: Sized,
@@ -1148,20 +1208,27 @@ fn test_outline_attr_on_block() -> Result<()> {
 #[cfg_attr(target_family = "wasm", wasm_bindgen_test)]
 fn test_type_interface_handle() {
     let ctx = &mut Context::new();
-    let fp32 = FP32Type::get(ctx);
+    let generic_ty = Type::instantiate(VerifyIntrTypeGeneric {}, ctx);
     let i32_ty = IntegerType::get(ctx, 32, Signedness::Signed);
 
-    // `FP32Type` implements `FloatTypeInterface`
-    let handle: TypeInterfaceHandle<dyn FloatTypeInterface> = fp32.into();
+    // `VerifyIntrTypeGeneric` implements `TestTypeInterfaceGeneric<i32>`
+    let handle: TypeInterfaceHandle<dyn TestTypeInterfaceGeneric<i32>> = generic_ty.into();
     // Interface methods are available with no cast at the point of use.
-    assert_eq!(handle.deref(ctx).get_semantics().bits, 32);
-    assert_eq!(handle.to_handle(), fp32.to_handle());
+    assert_eq!(handle.deref(ctx).type_arg_name(), "i32");
+    assert_eq!(handle.to_handle(), generic_ty.to_handle());
 
     assert!(
-        TypeInterfaceHandle::<dyn FloatTypeInterface>::from_handle(fp32.to_handle(), ctx).is_ok()
+        TypeInterfaceHandle::<dyn TestTypeInterfaceGeneric<i32>>::from_handle(
+            generic_ty.to_handle(),
+            ctx
+        )
+        .is_ok()
     );
     assert!(matches!(
-        TypeInterfaceHandle::<dyn FloatTypeInterface>::from_handle(i32_ty.to_handle(), ctx),
+        TypeInterfaceHandle::<dyn TestTypeInterfaceGeneric<i32>>::from_handle(
+            i32_ty.to_handle(),
+            ctx
+        ),
         Err(Error {
             kind: ErrorKind::InvalidArgument,
             err,


### PR DESCRIPTION
`#[attr_interface]` now also implements, for the interface object, the traits that `AttrObj` already has: `PartialEq`, `Eq`, `Hash`, `Printable` and `Parsable`. They all delegate to the attribute that the object holds, so a `Box<dyn I>` prints and parses in the same form as an `AttrObj`, and compares and hashes the same way.

An interface cannot have a lifetime parameter any more, because the object traits need `'static`. This is a new error in the macro.
