### PR TITLE
fix(graph): handle unreachable blocks in dominance frontier

### DIFF
--- a/src/graph/dominance.rs
+++ b/src/graph/dominance.rs
@@ -236,7 +236,7 @@ where
         let mut res: HMap<G::Node, ISet<G::Node>> =
             graph.nodes(ctx).map(|n| (n, ISet::default())).collect();
         for b in graph.nodes(ctx) {
-            if graph.num_predecessors(ctx, &b) < 2 {
+            if !dom_tree.contains(&b) || graph.num_predecessors(ctx, &b) < 2 {
                 continue;
             }
             let preds = graph.predecessors(ctx, &b);
@@ -825,6 +825,42 @@ mod tests {
         let dom = compute_dominator_tree(&ctx, &ArenaGraph);
         let df = DomFrontierMap::new(&ctx, &ArenaGraph, &dom);
         assert_eq!(*df.frontier(&4), ISet::from_iter([3, 4, 11, 12]));
+    }
+
+    #[test]
+    fn dom_frontier_unreachable_multi_predecessor() {
+        // reachable:
+        //      0 (entry) -> 1 (exit)
+        // unreachable:
+        //      2 (dead_a) ----\
+        //                      -> 4 (dead_join)
+        //      3 (dead_b) ----/
+        let ctx = vec![
+            /* 0 */ n(&[1]),
+            /* 1 */ n(&[]),
+            /* 2 */ n(&[4]),
+            /* 3 */ n(&[4]),
+            /* 4 */ n(&[]),
+        ];
+        let dom = compute_dominator_tree(&ctx, &ArenaGraph);
+        assert_eq!(dom.root(), Some(0));
+        assert_eq!(dom.num_nodes(), 2);
+        assert!(dom.contains(&0));
+        assert!(dom.contains(&1));
+        assert!(!dom.contains(&2));
+        assert!(!dom.contains(&3));
+        assert!(!dom.contains(&4));
+
+        let df = DomFrontierMap::new(&ctx, &ArenaGraph, &dom);
+
+        // Reachable-node behavior remains unchanged.
+        assert_eq!(*df.frontier(&0), ISet::from_iter([]));
+        assert_eq!(*df.frontier(&1), ISet::from_iter([]));
+
+        // Unreachable nodes (including multi-predecessor join) receive empty frontiers.
+        assert_eq!(*df.frontier(&2), ISet::from_iter([]));
+        assert_eq!(*df.frontier(&3), ISet::from_iter([]));
+        assert_eq!(*df.frontier(&4), ISet::from_iter([]));
     }
 
     // --- Operation-level dominance tests ---

--- a/tests/opts/mem2reg.rs
+++ b/tests/opts/mem2reg.rs
@@ -1032,3 +1032,35 @@ fn mem2reg_alloca_inside_loop_body() -> Result<()> {
         }"#]].assert_eq(&after);
     Ok(())
 }
+
+#[test]
+fn mem2reg_unreachable_multi_pred_block() -> Result<()> {
+    // Test that mem2reg succeeds on a valid function containing an unreachable
+    // block with multiple predecessors (which previously caused DomFrontierMap::new
+    // to panic).
+    let input = r#"
+    llvm.func @f: llvm.func <builtin.integer i64 () variadic = false> [] {
+      ^entry():
+      size = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64;
+      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr (0);
+      stored_val = builtin.constant <builtin.integer <42: i64>> : builtin.integer i64;
+      llvm.store *alloc <- stored_val;
+      loaded_val = llvm.load alloc : builtin.integer i64;
+      llvm.return loaded_val
+
+      ^dead_a():
+      llvm.br ^dead_join()
+
+      ^dead_b():
+      llvm.br ^dead_join()
+
+      ^dead_join():
+      c = builtin.constant <builtin.integer <0: i64>> : builtin.integer i64;
+      llvm.return c
+    }
+  "#;
+
+    let (status, _after) = run_mem2reg(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    Ok(())
+}


### PR DESCRIPTION
## Problem

`DomFrontierMap::new` iterates over all CFG nodes, including nodes unreachable
from the dominator-tree entry.

For an unreachable block with multiple predecessors, the implementation
attempts to compute its immediate dominator even though unreachable blocks are
not present in the dominator tree. This causes a panic.

This can also be reached through `mem2reg`.

## Fix

Skip blocks that are not contained in the dominator tree when computing
dominance frontiers.

Unreachable blocks remain present in the resulting map with empty frontiers.

## Tests

- Added a graph-level regression test for an unreachable multi-predecessor block.
- Added a `mem2reg` integration regression covering the same CFG shape.
- `cargo fmt --check`
- `graph::dominance`: 26 passed
- `mem2reg`: 21 passed
- Full workspace test suite: passing