### PR TITLE
fix(ir): reject erasing blocks with used arguments

### DIFF
--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -296,6 +296,13 @@ impl BasicBlock {
             ptr.deref(ctx).unique_name(ctx),
             ptr.preds(ctx).first().unwrap().deref(ctx).unique_name(ctx)
         );
+        if let Some(arg) = ptr.deref(ctx).arguments().find(|arg| arg.is_used(ctx)) {
+            panic!(
+                "Attempting to erase block {} whose argument {} has use outside the block",
+                ptr.deref(ctx).unique_name(ctx),
+                arg.unique_name(ctx)
+            );
+        }
         if let Some(op) = ptr.deref(ctx).iter(ctx).find(|op| op.deref(ctx).has_use()) {
             panic!(
                 "Attemping to erase block {} which contains {} with use outside the block",

--- a/tests/ir_construct.rs
+++ b/tests/ir_construct.rs
@@ -1517,6 +1517,47 @@ fn test_verify_operation_fails_on_undominated_block_argument_use() {
     assert!(matches!(err, DefUseVerifyErr::UseNotDominatedByDef(_)));
 }
 
+// Ensure that erasing a block whose argument has uses outside the block panics.
+#[test]
+#[cfg_attr(target_family = "wasm", wasm_bindgen_test)]
+#[should_panic(expected = "has use outside the block")]
+fn erase_block_with_used_argument() {
+    let ctx = &mut Context::new();
+    let i64_ty = IntegerType::get(ctx, 64, Signedness::Signed);
+    let func_ty =
+        pliron::builtin::types::FunctionType::get(ctx, vec![i64_ty.into()], vec![i64_ty.into()]);
+    let module = pliron::builtin::ops::ModuleOp::new(ctx, "bar".try_into().unwrap());
+    let func = pliron::builtin::ops::FuncOp::new(ctx, "foo".try_into().unwrap(), func_ty);
+    module.append_operation(ctx, func.get_operation(), 0);
+
+    let entry = func.get_entry_block(ctx);
+    let arg = entry.deref(ctx).get_argument(0);
+
+    let bb2 = BasicBlock::new(ctx, None, vec![]);
+    bb2.insert_after(ctx, entry);
+
+    let br = Operation::new(
+        ctx,
+        BranchOp::get_concrete_op_info(),
+        vec![],
+        vec![],
+        vec![bb2],
+        0,
+    );
+    br.insert_at_back(entry, ctx);
+
+    ReturnOp::new(ctx, arg)
+        .get_operation()
+        .insert_at_back(bb2, ctx);
+
+    // Initial IR must be completely valid and verified before erase.
+    verify_operation(module.get_operation(), ctx).expect("IR should be valid");
+
+    // Precondition violation: entry has an argument used outside the block.
+    // Erasing entry must panic.
+    BasicBlock::erase(entry, ctx);
+}
+
 #[test]
 fn block_inline_attrs_print() -> Result<()> {
     let ctx = &mut Context::new();


### PR DESCRIPTION
## Problem

`BasicBlock::erase` promises to panic when there are uses outside the block, but only checks CFG predecessors and uses of operations contained in the block.

It does not check uses of block arguments.

As a result, a block whose argument is still used by an operation in a successor block can be deallocated successfully, leaving the external operand pointing at a freed block argument. Subsequent use or cleanup of that operand can panic with `Dangling Ptr deref`.

## Fix

Check block arguments for remaining uses after dropping all uses held by operations inside the block and before deallocating the block.

Any remaining argument use at that point is an external use.

## Tests

- Added a regression test using valid, verifier-approved CFG/SSA IR.
- The test verifies that `BasicBlock::erase` panics when an entry block argument is used in a successor block.
- `cargo fmt --check` passes.
- Clippy with `-D warnings` passes.
- Core workspace tests pass.
- LLVM execution failures are due to the local LLVM 22/LLVM 23 toolchain mismatch, not this change.