### PR TITLE
[pliron-llvm] Implement constant folding for FPExtOp and FPTruncOp

### DIFF
--- a/pliron-llvm/src/interface_impls.rs
+++ b/pliron-llvm/src/interface_impls.rs
@@ -13,9 +13,9 @@ use pliron::{
     basic_block::BasicBlock,
     builtin::{
         attr_interfaces::FloatAttr,
-        attributes::IntegerAttr,
+        attributes::{FPDoubleAttr, FPHalfAttr, FPSingleAttr, IntegerAttr},
         op_interfaces::{BranchOpInterface, OneResultInterface},
-        types::{IntegerType, Signedness},
+        types::{FP16Type, FP32Type, FP64Type, IntegerType, Signedness},
     },
     context::{Context, Ptr},
     derive::op_interface_impl,
@@ -29,7 +29,11 @@ use pliron::{
         },
     },
     result::Result,
-    utils::apint::{APInt, bw},
+    r#type::TypeHandle,
+    utils::{
+        apfloat::FloatConvert,
+        apint::{APInt, bw},
+    },
     value::Value,
 };
 
@@ -315,6 +319,60 @@ fn fast_math_forbids_fold(flags: FastmathFlagsAttr, values: &[&dyn FloatAttr]) -
     let flags = flags.0;
     (flags.contains(FastmathFlags::NNAN) && values.iter().any(|v| v.is_nan()))
         || (flags.contains(FastmathFlags::NINF) && values.iter().any(|v| v.is_infinite()))
+}
+
+/// Convert a scalar floating-point attribute to `result_ty`. The verifier guarantees
+/// that the source and destination are different floating-point types.
+fn convert_float_attr(ctx: &Context, operand: &AttrObj, result_ty: TypeHandle) -> AttrObj {
+    let result_ty = result_ty.deref(ctx);
+
+    if result_ty.is::<FP16Type>() {
+        if let Some(value) = operand.downcast_ref::<FPSingleAttr>() {
+            return Box::new(FPHalfAttr(value.0.convert(&mut false).value)) as AttrObj;
+        }
+        if let Some(value) = operand.downcast_ref::<FPDoubleAttr>() {
+            return Box::new(FPHalfAttr(value.0.convert(&mut false).value)) as AttrObj;
+        }
+    } else if result_ty.is::<FP32Type>() {
+        if let Some(value) = operand.downcast_ref::<FPHalfAttr>() {
+            return Box::new(FPSingleAttr(value.0.convert(&mut false).value)) as AttrObj;
+        }
+        if let Some(value) = operand.downcast_ref::<FPDoubleAttr>() {
+            return Box::new(FPSingleAttr(value.0.convert(&mut false).value)) as AttrObj;
+        }
+    } else if result_ty.is::<FP64Type>() {
+        if let Some(value) = operand.downcast_ref::<FPHalfAttr>() {
+            return Box::new(FPDoubleAttr(value.0.convert(&mut false).value)) as AttrObj;
+        }
+        if let Some(value) = operand.downcast_ref::<FPSingleAttr>() {
+            return Box::new(FPDoubleAttr(value.0.convert(&mut false).value)) as AttrObj;
+        }
+    }
+
+    panic!("invalid floating-point cast: typecheck before optimizing")
+}
+
+/// Constant fold a scalar floating-point cast.
+fn check_fold_float_cast(
+    ctx: &Context,
+    operand_attrs: &[Option<AttrObj>],
+    result_ty: TypeHandle,
+    flags: FastmathFlagsAttr,
+) -> Vec<Option<AttrObj>> {
+    let [Some(operand)] = operand_attrs else {
+        return vec![None];
+    };
+    let Some(source) = attr_cast::<dyn FloatAttr>(&**operand) else {
+        return vec![None];
+    };
+    let result = convert_float_attr(ctx, operand, result_ty);
+    let result_float = attr_cast::<dyn FloatAttr>(&*result)
+        .expect("floating-point conversion must produce a floating-point attribute");
+
+    if fast_math_forbids_fold(flags, &[source, result_float]) {
+        return vec![None];
+    }
+    vec![Some(result)]
 }
 
 /// Constant fold a binary floating-point operation into a singleton vector
@@ -735,6 +793,36 @@ impl ConstFoldInterface for ZExtOp {
             value.zext(NonZero::new(dest_width as usize).expect("result has zero bitwidth"));
         let res = Box::new(IntegerAttr::new(dest_ty, extended)) as AttrObj;
         vec![Some(res)]
+    }
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for FPExtOp {
+    fn check_fold(&self, ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        check_fold_float_cast(ctx, ops, self.result_type(ctx), self.fast_math_flags(ctx))
+    }
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for FPTruncOp {
+    fn check_fold(&self, ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        check_fold_float_cast(ctx, ops, self.result_type(ctx), self.fast_math_flags(ctx))
     }
     fn fold_in_place(
         &self,

--- a/pliron-llvm/tests/opts/constants.rs
+++ b/pliron-llvm/tests/opts/constants.rs
@@ -1511,6 +1511,216 @@ fn zext_does_not_fold_with_non_constant_operand() -> Result<()> {
 }
 
 // ---------------------------------------------------------------------------
+// llvm.fpext
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fpext_folds_fp16_to_fp32() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.half 1.5> : builtin.fp16;
+        c = llvm.fpext <> a to builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("builtin.single 1.5"));
+    Ok(())
+}
+
+#[test]
+fn fpext_folds_fp16_to_fp64() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp64 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.half 1.5> : builtin.fp16;
+        c = llvm.fpext <> a to builtin.fp64;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("builtin.double 1.5"));
+    Ok(())
+}
+
+#[test]
+fn fpext_folds_fp32_to_fp64() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp64 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 2.5> : builtin.fp32;
+        c = llvm.fpext <> a to builtin.fp64;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("builtin.double 2.5"));
+    Ok(())
+}
+
+#[test]
+fn fpext_nnan_does_not_fold_nan() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp64 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single NaN> : builtin.fp32;
+        c = llvm.fpext <NNAN> a to builtin.fp64;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn fpext_ninf_does_not_fold_infinity() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp64 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single +Inf> : builtin.fp32;
+        c = llvm.fpext <NINF> a to builtin.fp64;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn fpext_does_not_fold_with_non_constant_operand() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp64 (builtin.fp32) variadic = false> [] {
+        ^entry(x: builtin.fp32):
+        c = llvm.fpext <> x to builtin.fp64;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// llvm.fptrunc
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fptrunc_folds_fp64_to_fp32() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.double 2.5> : builtin.fp64;
+        c = llvm.fptrunc <> a to builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("builtin.single 2.5"));
+    Ok(())
+}
+
+#[test]
+fn fptrunc_folds_fp64_to_fp16() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp16 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.double 1.5> : builtin.fp64;
+        c = llvm.fptrunc <> a to builtin.fp16;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("builtin.half 1.5"));
+    Ok(())
+}
+
+#[test]
+fn fptrunc_folds_fp32_to_fp16() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp16 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 3.25> : builtin.fp32;
+        c = llvm.fptrunc <> a to builtin.fp16;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("builtin.half 3.25"));
+    Ok(())
+}
+
+#[test]
+fn fptrunc_rounds_to_destination_precision() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.double 1.0000000001> : builtin.fp64;
+        c = llvm.fptrunc <> a to builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("builtin.single 1"));
+    Ok(())
+}
+
+#[test]
+fn fptrunc_nnan_does_not_fold_nan() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.double NaN> : builtin.fp64;
+        c = llvm.fptrunc <NNAN> a to builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+/// A finite fp64 value can overflow to infinity when truncated to fp32. With
+/// `ninf`, that result is poison and must not be folded to a concrete value.
+#[test]
+fn fptrunc_ninf_does_not_fold_overflow_to_infinity() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.double 1e300> : builtin.fp64;
+        c = llvm.fptrunc <NINF> a to builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn fptrunc_does_not_fold_with_non_constant_operand() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 (builtin.fp64) variadic = false> [] {
+        ^entry(x: builtin.fp64):
+        c = llvm.fptrunc <> x to builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // llvm.fneg
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Implement `ConstFoldInterface` for the LLVM dialect's `FPExtOp` and `FPTruncOp` as part of #118.

The implementation folds constant scalar floating-point casts between the currently supported `fp16`, `fp32`, and `fp64` types.

## Changes

* Add a shared helper for converting constant floating-point attributes between `fp16`, `fp32`, and `fp64`.
* Implement `ConstFoldInterface` for `FPExtOp`.
* Implement `ConstFoldInterface` for `FPTruncOp`.
* Preserve destination floating-point precision when truncating.
* Avoid folding when `nnan` or `ninf` fast-math assumptions would be violated.
* Handle the case where a finite value becomes infinity after truncation under `ninf`.
* Add SCCP tests covering:

  * `fp16 -> fp32`
  * `fp16 -> fp64`
  * `fp32 -> fp64`
  * `fp64 -> fp32`
  * `fp64 -> fp16`
  * `fp32 -> fp16`
  * destination-precision rounding
  * `nnan`
  * `ninf`
  * non-constant operands

This works on #118 but does not close the issue.

## Testing

Validated with:

```text
cargo test -p pliron-llvm --test opt_tests fpext -- --nocapture
cargo test -p pliron-llvm --test opt_tests fptrunc -- --nocapture
cargo test -p pliron-llvm --test opt_tests

cargo fmt --all -- --check

cargo clippy -p pliron-llvm --all-targets --all-features -- -D warnings

cargo check -p pliron-llvm --no-default-features
RUSTFLAGS="-D warnings" cargo test -p pliron-llvm --no-default-features

./pre-ci.sh
```

All checks pass.

## Checklist

* [x] I have read [CONTRIBUTING.md](../blob/HEAD/CONTRIBUTING.md).
* [x] A human is involved in writing this PR description and will handle review interactions, per our [AI tool policy](../blob/HEAD/CONTRIBUTING.md).
* [x] I understand every part of this change (including any AI-generated code) and can explain the reasoning behind it.
* [ ] Intrusive / large changes were discussed on Discord before this PR.
* [x] `pre-ci.sh` passes locally.
