### PR TITLE
[pliron-llvm] Implement constant folding for SIToFPOp and UIToFPOp

### DIFF
--- a/pliron-llvm/src/interface_impls.rs
+++ b/pliron-llvm/src/interface_impls.rs
@@ -13,9 +13,9 @@ use pliron::{
     basic_block::BasicBlock,
     builtin::{
         attr_interfaces::FloatAttr,
-        attributes::IntegerAttr,
+        attributes::{FPDoubleAttr, FPHalfAttr, FPSingleAttr, IntegerAttr},
         op_interfaces::{BranchOpInterface, OneResultInterface},
-        types::{IntegerType, Signedness},
+        types::{FP16Type, FP32Type, FP64Type, IntegerType, Signedness},
     },
     context::{Context, Ptr},
     derive::op_interface_impl,
@@ -29,7 +29,11 @@ use pliron::{
         },
     },
     result::Result,
-    utils::apint::{APInt, bw},
+    r#type::TypeHandle,
+    utils::{
+        apfloat::{Double, Float, Half, Single},
+        apint::{APInt, bw},
+    },
     value::Value,
 };
 
@@ -315,6 +319,77 @@ fn fast_math_forbids_fold(flags: FastmathFlagsAttr, values: &[&dyn FloatAttr]) -
     let flags = flags.0;
     (flags.contains(FastmathFlags::NNAN) && values.iter().any(|v| v.is_nan()))
         || (flags.contains(FastmathFlags::NINF) && values.iter().any(|v| v.is_infinite()))
+}
+
+/// Convert a scalar integer constant to a floating-point attribute.
+///
+/// `signed` controls whether the input bit pattern is interpreted as a signed
+/// or unsigned integer. Values wider than 128 bits are left unfolded because
+/// rustc_apfloat's integer conversion entry points accept at most 128 bits.
+fn convert_int_to_float_attr(
+    ctx: &Context,
+    value: &APInt,
+    result_ty: TypeHandle,
+    signed: bool,
+) -> Option<AttrObj> {
+    if value.bw() > 128 {
+        return None;
+    }
+
+    let result_ty = result_ty.deref(ctx);
+    if result_ty.is::<FP16Type>() {
+        let value = if signed {
+            Half::from_i128(value.to_i128()).value
+        } else {
+            Half::from_u128(value.to_u128()).value
+        };
+        Some(Box::new(FPHalfAttr(value)) as AttrObj)
+    } else if result_ty.is::<FP32Type>() {
+        let value = if signed {
+            Single::from_i128(value.to_i128()).value
+        } else {
+            Single::from_u128(value.to_u128()).value
+        };
+        Some(Box::new(FPSingleAttr(value)) as AttrObj)
+    } else if result_ty.is::<FP64Type>() {
+        let value = if signed {
+            Double::from_i128(value.to_i128()).value
+        } else {
+            Double::from_u128(value.to_u128()).value
+        };
+        Some(Box::new(FPDoubleAttr(value)) as AttrObj)
+    } else {
+        panic!("invalid integer-to-floating-point cast: typecheck before optimizing")
+    }
+}
+
+/// Constant fold a scalar integer-to-floating-point cast.
+fn check_fold_int_to_float(
+    ctx: &Context,
+    operand_attrs: &[Option<AttrObj>],
+    result_ty: TypeHandle,
+    signed: bool,
+    nneg: bool,
+) -> Vec<Option<AttrObj>> {
+    let [Some(operand)] = operand_attrs else {
+        return vec![None];
+    };
+    let operand = operand
+        .downcast_ref::<IntegerAttr>()
+        .expect("invalid operand type: typecheck before optimizing");
+    let value = operand.value();
+
+    // `uitofp nneg` produces poison when the input bit pattern is negative
+    // under signed interpretation.
+    if nneg
+        && value.slt(&APInt::zero(
+            NonZero::new(value.bw()).expect("operand has zero bitwidth"),
+        ))
+    {
+        return vec![None];
+    }
+
+    vec![convert_int_to_float_attr(ctx, &value, result_ty, signed)]
 }
 
 /// Constant fold a binary floating-point operation into a singleton vector
@@ -736,6 +811,38 @@ impl ConstFoldInterface for ZExtOp {
         let res = Box::new(IntegerAttr::new(dest_ty, extended)) as AttrObj;
         vec![Some(res)]
     }
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for SIToFPOp {
+    fn check_fold(&self, ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        check_fold_int_to_float(ctx, ops, self.result_type(ctx), true, false)
+    }
+
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for UIToFPOp {
+    fn check_fold(&self, ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        check_fold_int_to_float(ctx, ops, self.result_type(ctx), false, self.nneg(ctx))
+    }
+
     fn fold_in_place(
         &self,
         ctx: &mut Context,

--- a/pliron-llvm/tests/opts/constants.rs
+++ b/pliron-llvm/tests/opts/constants.rs
@@ -1511,6 +1511,215 @@ fn zext_does_not_fold_with_non_constant_operand() -> Result<()> {
 }
 
 // ---------------------------------------------------------------------------
+// llvm.sitofp
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sitofp_folds_positive_i16_to_fp16() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp16 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <42: i16>> : builtin.integer i16;
+        c = llvm.sitofp a to builtin.fp16;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("builtin.half 42"));
+    Ok(())
+}
+
+#[test]
+fn sitofp_folds_positive_i32_to_fp32() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <257: i32>> : builtin.integer i32;
+        c = llvm.sitofp a to builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("builtin.single 257"));
+    Ok(())
+}
+
+#[test]
+fn sitofp_interprets_high_bit_as_negative() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp64 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <255: i8>> : builtin.integer i8;
+        c = llvm.sitofp a to builtin.fp64;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("builtin.double -1"));
+    Ok(())
+}
+
+#[test]
+fn sitofp_rounds_to_destination_precision() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <16777217: i32>> : builtin.integer i32;
+        c = llvm.sitofp a to builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("builtin.single 16777216"));
+    Ok(())
+}
+
+#[test]
+fn sitofp_does_not_fold_integer_wider_than_128_bits() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp64 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <1: i129>> : builtin.integer i129;
+        c = llvm.sitofp a to builtin.fp64;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn sitofp_does_not_fold_with_non_constant_operand() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 (builtin.integer i32) variadic = false> [] {
+        ^entry(x: builtin.integer i32):
+        c = llvm.sitofp x to builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// llvm.uitofp
+// ---------------------------------------------------------------------------
+
+#[test]
+fn uitofp_folds_i16_to_fp16() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp16 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <42: i16>> : builtin.integer i16;
+        c = llvm.uitofp <nneg=false> a to builtin.fp16;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("builtin.half 42"));
+    Ok(())
+}
+
+#[test]
+fn uitofp_folds_i32_to_fp32() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <257: i32>> : builtin.integer i32;
+        c = llvm.uitofp <nneg=false> a to builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("builtin.single 257"));
+    Ok(())
+}
+
+#[test]
+fn uitofp_interprets_high_bit_as_unsigned() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp64 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <255: i8>> : builtin.integer i8;
+        c = llvm.uitofp <nneg=false> a to builtin.fp64;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("builtin.double 255"));
+    Ok(())
+}
+
+#[test]
+fn uitofp_nneg_does_not_fold_negative_constant() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp64 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <255: i8>> : builtin.integer i8;
+        c = llvm.uitofp <nneg=true> a to builtin.fp64;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn uitofp_nneg_folds_non_negative_constant() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp64 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <42: i8>> : builtin.integer i8;
+        c = llvm.uitofp <nneg=true> a to builtin.fp64;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("builtin.double 42"));
+    Ok(())
+}
+
+#[test]
+fn uitofp_does_not_fold_integer_wider_than_128_bits() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp64 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <1: i129>> : builtin.integer i129;
+        c = llvm.uitofp <nneg=false> a to builtin.fp64;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn uitofp_does_not_fold_with_non_constant_operand() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 (builtin.integer i32) variadic = false> [] {
+        ^entry(x: builtin.integer i32):
+        c = llvm.uitofp <nneg=false> x to builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // llvm.fneg
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Implement `ConstFoldInterface` for the LLVM dialect's `SIToFPOp` and `UIToFPOp` as part of #118.

The implementation folds constant scalar integer-to-floating-point conversions for the currently supported floating-point types.

## Changes

* Implement constant folding for `SIToFPOp`.
* Implement constant folding for `UIToFPOp`.
* Preserve signed interpretation for `sitofp`.
* Preserve unsigned interpretation for `uitofp`.
* Respect the `nneg` flag on `UIToFPOp`.
* Round results to the destination floating-point precision.
* Conservatively avoid folding integer constants wider than 128 bits.
* Add SCCP tests covering:

  * signed and unsigned conversions
  * `fp16`, `fp32`, and `fp64` destinations
  * high-bit signed/unsigned interpretation
  * destination-precision rounding
  * `nneg`
  * non-constant operands
  * integer operands wider than 128 bits

This works on #118 but does not close the issue.

## Testing

Validated with:

```text
cargo test -p pliron-llvm --test opt_tests sitofp -- --nocapture
cargo test -p pliron-llvm --test opt_tests uitofp -- --nocapture
cargo test -p pliron-llvm --test opt_tests

cargo fmt --all -- --check

cargo clippy -p pliron-llvm --all-targets --all-features -- -D warnings

cargo check -p pliron-llvm --no-default-features
RUSTFLAGS="-D warnings" cargo test -p pliron-llvm --no-default-features

./pre-ci.sh
```

All checks pass.

## Checklist

* [x] I have read [CONTRIBUTING.md](../blob/HEAD/CONTRIBUTING.md).
* [x] A human is involved in writing this PR description and will handle review interactions, per our [AI tool policy](../blob/HEAD/CONTRIBUTING.md).
* [x] I understand every part of this change (including any AI-generated code) and can explain the reasoning behind it.
* [ ] Intrusive / large changes were discussed on Discord before this PR.
* [x] `pre-ci.sh` passes locally.