### PR TITLE
[pliron-llvm] Implement constant folding for FPToSIOp and FPToUIOp

### DIFF
--- a/pliron-llvm/src/interface_impls.rs
+++ b/pliron-llvm/src/interface_impls.rs
@@ -29,7 +29,11 @@ use pliron::{
         },
     },
     result::Result,
-    utils::apint::{APInt, bw},
+    r#type::TypeHandle,
+    utils::{
+        apfloat::Round,
+        apint::{APInt, bw},
+    },
     value::Value,
 };
 
@@ -315,6 +319,73 @@ fn fast_math_forbids_fold(flags: FastmathFlagsAttr, values: &[&dyn FloatAttr]) -
     let flags = flags.0;
     (flags.contains(FastmathFlags::NNAN) && values.iter().any(|v| v.is_nan()))
         || (flags.contains(FastmathFlags::NINF) && values.iter().any(|v| v.is_infinite()))
+}
+
+// rustc_apfloat::Status::INVALID_OP. `Status` is not re-exported by Pliron,
+// while `StatusAnd` exposes its bitset through `bits()`.
+const APFLOAT_INVALID_OP: u8 = 0x01;
+
+/// Constant fold a scalar floating-point-to-integer cast.
+///
+/// LLVM rounds `fptosi` and `fptoui` toward zero. A conversion that cannot be
+/// represented in the destination integer type produces poison, so an
+/// `INVALID_OP` result from rustc_apfloat must not be materialized. Integer
+/// destinations wider than 128 bits are left unfolded because rustc_apfloat's
+/// integer conversion entry points return at most 128 bits.
+fn check_fold_float_to_int(
+    ctx: &Context,
+    operand_attrs: &[Option<AttrObj>],
+    result_ty: TypeHandle,
+    signed: bool,
+) -> Vec<Option<AttrObj>> {
+    let [Some(operand)] = operand_attrs else {
+        return vec![None];
+    };
+    let Some(value) = attr_cast::<dyn FloatAttr>(&**operand) else {
+        return vec![None];
+    };
+
+    let result_ty = result_ty.deref(ctx);
+    let Some(int_ty) = result_ty.downcast_ref::<IntegerType>() else {
+        return vec![None];
+    };
+    let dest_width = int_ty.width() as usize;
+    if dest_width > 128 {
+        return vec![None];
+    }
+
+    let mut is_exact = false;
+    let converted = if signed {
+        // rustc_apfloat implements signed conversion in terms of an unsigned
+        // conversion with one fewer value bit. For i1 that would request an
+        // unsupported zero-bit unsigned conversion, so use i2 temporarily and
+        // then enforce the signed i1 range {-1, 0} explicitly.
+        let conversion_width = dest_width.max(2);
+        let converted = value.to_i128_r(conversion_width, Round::TowardZero, &mut is_exact);
+        if (converted.status.bits() & APFLOAT_INVALID_OP) != 0
+            || (dest_width == 1 && converted.value != -1 && converted.value != 0)
+        {
+            return vec![None];
+        }
+        APInt::from_i128(
+            converted.value,
+            NonZero::new(dest_width).expect("result has zero bitwidth"),
+        )
+    } else {
+        let converted = value.to_u128_r(dest_width, Round::TowardZero, &mut is_exact);
+        if (converted.status.bits() & APFLOAT_INVALID_OP) != 0 {
+            return vec![None];
+        }
+        APInt::from_u128(
+            converted.value,
+            NonZero::new(dest_width).expect("result has zero bitwidth"),
+        )
+    };
+
+    let dest_ty = IntegerType::get(ctx, int_ty.width(), Signedness::Signless);
+    vec![Some(
+        Box::new(IntegerAttr::new(dest_ty, converted)) as AttrObj
+    )]
 }
 
 /// Constant fold a binary floating-point operation into a singleton vector
@@ -736,6 +807,38 @@ impl ConstFoldInterface for ZExtOp {
         let res = Box::new(IntegerAttr::new(dest_ty, extended)) as AttrObj;
         vec![Some(res)]
     }
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for FPToSIOp {
+    fn check_fold(&self, ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        check_fold_float_to_int(ctx, ops, self.result_type(ctx), true)
+    }
+
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for FPToUIOp {
+    fn check_fold(&self, ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        check_fold_float_to_int(ctx, ops, self.result_type(ctx), false)
+    }
+
     fn fold_in_place(
         &self,
         ctx: &mut Context,

--- a/pliron-llvm/tests/opts/constants.rs
+++ b/pliron-llvm/tests/opts/constants.rs
@@ -1511,6 +1511,291 @@ fn zext_does_not_fold_with_non_constant_operand() -> Result<()> {
 }
 
 // ---------------------------------------------------------------------------
+// llvm.fptosi
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fptosi_truncates_positive_fraction_toward_zero() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 3.75> : builtin.fp32;
+        c = llvm.fptosi a to builtin.integer i8;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("builtin.integer <3: i8>"));
+    Ok(())
+}
+
+#[test]
+fn fptosi_truncates_negative_fraction_toward_zero() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.double -123.75> : builtin.fp64;
+        c = llvm.fptosi a to builtin.integer i8;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    // -123 is represented by the i8 bit pattern 133.
+    assert!(after.contains("builtin.integer <133: i8>"));
+    Ok(())
+}
+
+#[test]
+fn fptosi_folds_fraction_at_signed_lower_boundary() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.double -128.9> : builtin.fp64;
+        c = llvm.fptosi a to builtin.integer i8;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    // -128 is represented by the i8 bit pattern 128.
+    assert!(after.contains("builtin.integer <128: i8>"));
+    Ok(())
+}
+
+#[test]
+fn fptosi_does_not_fold_out_of_range_value() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 128> : builtin.fp32;
+        c = llvm.fptosi a to builtin.integer i8;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn fptosi_does_not_fold_nan() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single NaN> : builtin.fp32;
+        c = llvm.fptosi a to builtin.integer i32;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn fptosi_does_not_fold_infinity() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.double +Inf> : builtin.fp64;
+        c = llvm.fptosi a to builtin.integer i32;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn fptosi_folds_to_i1() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i1 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 0.75> : builtin.fp32;
+        c = llvm.fptosi a to builtin.integer i1;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("builtin.integer <0: i1>"));
+    Ok(())
+}
+
+#[test]
+fn fptosi_does_not_fold_integer_wider_than_128_bits() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i129 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.double 1> : builtin.fp64;
+        c = llvm.fptosi a to builtin.integer i129;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn fptosi_does_not_fold_with_non_constant_operand() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i32 (builtin.fp32) variadic = false> [] {
+        ^entry(x: builtin.fp32):
+        c = llvm.fptosi x to builtin.integer i32;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// llvm.fptoui
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fptoui_folds_positive_constant() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i16 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.half 42> : builtin.fp16;
+        c = llvm.fptoui a to builtin.integer i16;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("builtin.integer <42: i16>"));
+    Ok(())
+}
+
+#[test]
+fn fptoui_truncates_fraction_toward_zero() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.double 255.9> : builtin.fp64;
+        c = llvm.fptoui a to builtin.integer i8;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("builtin.integer <255: i8>"));
+    Ok(())
+}
+
+#[test]
+fn fptoui_folds_negative_fraction_to_zero() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.double -0.999> : builtin.fp64;
+        c = llvm.fptoui a to builtin.integer i32;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("builtin.integer <0: i32>"));
+    Ok(())
+}
+
+#[test]
+fn fptoui_does_not_fold_negative_one() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single -1> : builtin.fp32;
+        c = llvm.fptoui a to builtin.integer i32;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn fptoui_does_not_fold_out_of_range_value() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 256> : builtin.fp32;
+        c = llvm.fptoui a to builtin.integer i8;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn fptoui_does_not_fold_nan() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.double NaN> : builtin.fp64;
+        c = llvm.fptoui a to builtin.integer i32;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn fptoui_does_not_fold_infinity() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single +Inf> : builtin.fp32;
+        c = llvm.fptoui a to builtin.integer i32;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn fptoui_does_not_fold_integer_wider_than_128_bits() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i129 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.double 1> : builtin.fp64;
+        c = llvm.fptoui a to builtin.integer i129;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn fptoui_does_not_fold_with_non_constant_operand() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i32 (builtin.fp32) variadic = false> [] {
+        ^entry(x: builtin.fp32):
+        c = llvm.fptoui x to builtin.integer i32;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // llvm.fneg
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Implement `ConstFoldInterface` for the LLVM dialect's `FPToSIOp` and `FPToUIOp` as part of #118.

The implementation folds constant scalar floating-point-to-integer conversions while preserving LLVM's truncation and poison semantics.

## Changes

* Implement constant folding for `FPToSIOp`.
* Implement constant folding for `FPToUIOp`.
* Round floating-point values toward zero, matching LLVM semantics.
* Preserve signed and unsigned destination interpretation.
* Avoid folding NaN, infinity, and out-of-range values that would produce poison.
* Correctly fold fractional values that truncate to a representable integer.
* Handle `i1` destinations.
* Conservatively avoid folding integer destinations wider than 128 bits.
* Add SCCP tests covering:

  * positive and negative fractional truncation
  * signed and unsigned conversions
  * signed lower-bound behavior
  * negative fractions truncating to zero for `fptoui`
  * NaN and infinity
  * out-of-range values
  * `i1`
  * integer destinations wider than 128 bits
  * non-constant operands

This works on #118 but does not close the issue.

## Testing

Validated with:

```text
cargo test -p pliron-llvm --test opt_tests fptosi -- --nocapture
cargo test -p pliron-llvm --test opt_tests fptoui -- --nocapture
cargo test -p pliron-llvm --test opt_tests

cargo clippy -p pliron-llvm --all-targets --all-features -- -D warnings

./pre-ci.sh
```

All checks pass.

## Checklist

* [x] I have read [CONTRIBUTING.md](../blob/HEAD/CONTRIBUTING.md).
* [x] A human is involved in writing this PR description and will handle review interactions, per our [AI tool policy](../blob/HEAD/CONTRIBUTING.md).
* [x] I understand every part of this change (including any AI-generated code) and can explain the reasoning behind it.
* [ ] Intrusive / large changes were discussed on Discord before this PR.
* [x] `pre-ci.sh` passes locally.
