### PR TITLE
Benchmark fast SSA liveness on LLVM modules

### DIFF
--- a/pliron-llvm/llvm-opt/Cargo.toml
+++ b/pliron-llvm/llvm-opt/Cargo.toml
@@ -26,3 +26,7 @@ tempfile.workspace = true
 assert_cmd.workspace = true
 cargo-manifest.workspace = true
 which.workspace = true
+
+[[bench]]
+name = "liveness"
+harness = false

--- a/pliron-llvm/llvm-opt/benches/liveness.rs
+++ b/pliron-llvm/llvm-opt/benches/liveness.rs
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) The pliron contributors
+
+//! Benchmarks for the SSA liveness implementation.
+//!
+//! The corpus is read from `PLIRON_LIVENESS_BENCH_DIR`. Each `.ll`
+//! file in that directory is parsed independently, matching the per-module
+//! measurements requested by issue #100.
+//!
+//! This benchmark intentionally performs one exhaustive query sweep per module
+//! instead of statistical resampling. Large real-world modules can contain tens
+//! of millions of value/program-point pairs, so repeating the complete sweep
+//! would dominate the benchmark runtime without measuring a different workload.
+
+use std::{
+    any::Any,
+    env, fs,
+    hint::black_box,
+    panic::{AssertUnwindSafe, catch_unwind},
+    path::{Path, PathBuf},
+    time::{Duration, Instant},
+};
+
+use pliron::{
+    analyses::liveness::{Liveness, LivenessTq},
+    builtin::op_interfaces::{AtMostOneRegionInterface, SingleBlockRegionInterface},
+    context::{Context, Ptr},
+    graph::{
+        dominance::DomInfo,
+        walkers::{IRNode, WALKCONFIG_PREORDER_FORWARD, uninterruptible::immutable::walk_op},
+    },
+    irbuild::inserter::OpInsertionPoint,
+    linked_list::ContainsLinkedList,
+    op::Op,
+    operation::Operation,
+    pass::AnalysisManager,
+    value::Value,
+};
+use pliron_llvm::{
+    from_llvm_ir,
+    llvm_sys::core::{LLVMContext, LLVMModule},
+    ops::FuncOp,
+};
+
+const CORPUS_ENV: &str = "PLIRON_LIVENESS_BENCH_DIR";
+
+struct FunctionWorkload {
+    op: Ptr<Operation>,
+    values: Vec<Value>,
+    points: Vec<OpInsertionPoint>,
+}
+
+struct LoadedModule {
+    ctx: Context,
+    functions: Vec<FunctionWorkload>,
+    query_count: u64,
+}
+
+impl LoadedModule {
+    fn value_count(&self) -> usize {
+        self.functions
+            .iter()
+            .map(|workload| workload.values.len())
+            .sum()
+    }
+
+    fn point_count(&self) -> usize {
+        self.functions
+            .iter()
+            .map(|workload| workload.points.len())
+            .sum()
+    }
+}
+
+fn collect_ir_node(ctx: &Context, workload: &mut FunctionWorkload, node: IRNode) {
+    match node {
+        IRNode::BasicBlock(block) => {
+            workload.values.extend(block.deref(ctx).arguments());
+            workload.points.push(OpInsertionPoint::AtBlockStart(block));
+            workload.points.push(OpInsertionPoint::AtBlockEnd(block));
+        }
+        IRNode::Operation(op) => {
+            let op_ref = op.deref(ctx);
+            workload.values.extend(op_ref.results());
+            if op_ref.get_parent_block().is_some() {
+                workload.points.push(OpInsertionPoint::BeforeOperation(op));
+                workload.points.push(OpInsertionPoint::AfterOperation(op));
+            }
+        }
+        IRNode::Region(_) => {}
+    }
+}
+
+fn collect_function_workloads(
+    ctx: &Context,
+    module: &pliron::builtin::ops::ModuleOp,
+) -> Vec<FunctionWorkload> {
+    module
+        .get_body(ctx, 0)
+        .deref(ctx)
+        .iter(ctx)
+        .filter_map(|op| Operation::get_op::<FuncOp>(op, ctx))
+        .filter_map(|func| {
+            // LLVM declarations have no body and therefore no liveness workload.
+            func.get_region(ctx)?;
+
+            let mut workload = FunctionWorkload {
+                op: func.get_operation(),
+                values: Vec::new(),
+                points: Vec::new(),
+            };
+            walk_op(
+                ctx,
+                &mut workload,
+                &WALKCONFIG_PREORDER_FORWARD,
+                func.get_operation(),
+                collect_ir_node,
+            );
+            Some(workload)
+        })
+        .collect()
+}
+
+fn load_module(path: &Path) -> LoadedModule {
+    let mut ctx = Context::default();
+    let llvm_ctx = LLVMContext::default();
+    let llvm_module = LLVMModule::from_ir_in_file(
+        &llvm_ctx,
+        path.to_str().expect("benchmark corpus path must be UTF-8"),
+    )
+    .unwrap_or_else(|err| panic!("failed to parse {}: {err}", path.display()));
+    let module = from_llvm_ir::convert_module(&mut ctx, &llvm_module)
+        .unwrap_or_else(|err| panic!("failed to convert {} to pliron IR: {err}", path.display()));
+
+    let functions = collect_function_workloads(&ctx, &module);
+    let query_count = functions
+        .iter()
+        .map(|workload| (workload.values.len() as u64) * (workload.points.len() as u64))
+        .sum();
+
+    LoadedModule {
+        ctx,
+        functions,
+        query_count,
+    }
+}
+
+fn collect_corpus_files(dir: &Path, files: &mut Vec<PathBuf>) {
+    let entries = fs::read_dir(dir)
+        .unwrap_or_else(|err| panic!("failed to read benchmark corpus {}: {err}", dir.display()));
+
+    for entry in entries {
+        let path = entry.expect("failed to read corpus directory entry").path();
+        if path.is_dir() {
+            collect_corpus_files(&path, files);
+        } else if path.extension().and_then(|ext| ext.to_str()) == Some("ll") {
+            files.push(path);
+        }
+    }
+}
+
+fn corpus_files() -> Vec<PathBuf> {
+    let corpus_dir = env::var_os(CORPUS_ENV).unwrap_or_else(|| {
+        panic!("{CORPUS_ENV} must point to a directory containing LLVM .ll modules")
+    });
+    let corpus_dir = PathBuf::from(corpus_dir);
+    let mut files = Vec::new();
+    collect_corpus_files(&corpus_dir, &mut files);
+    files.sort();
+    assert!(
+        !files.is_empty(),
+        "{} contains no .ll modules",
+        corpus_dir.display()
+    );
+    files
+}
+
+fn precompute_all(module: &LoadedModule) -> AnalysisManager {
+    let mut analyses = AnalysisManager::default();
+    for workload in &module.functions {
+        analyses
+            .compute_analysis::<Liveness<LivenessTq>>(workload.op, &module.ctx)
+            .expect("liveness analysis must compute successfully");
+    }
+    analyses
+}
+
+fn run_all_queries(module: &LoadedModule, analyses: &mut AnalysisManager) -> usize {
+    let mut live_answers = 0usize;
+
+    for workload in &module.functions {
+        let op = workload.op;
+        let mut liveness = analyses
+            .try_get_analysis_mut::<Liveness<LivenessTq>>(op)
+            .expect("precomputed liveness analysis missing");
+        let mut dom_info = analyses
+            .try_get_analysis_mut::<DomInfo>(op)
+            .expect("precomputed dominance analysis missing");
+
+        for &value in &workload.values {
+            for &point in &workload.points {
+                live_answers +=
+                    liveness.is_live_at_point(&module.ctx, &mut dom_info, value, point) as usize;
+            }
+        }
+    }
+
+    live_answers
+}
+
+fn module_name(path: &Path) -> &str {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("module")
+}
+
+fn panic_message(payload: &(dyn Any + Send)) -> &str {
+    if let Some(message) = payload.downcast_ref::<&'static str>() {
+        message
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message
+    } else {
+        "non-string panic payload"
+    }
+}
+
+fn millis(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000.0
+}
+
+fn mega_queries_per_second(query_count: u64, duration: Duration) -> f64 {
+    if duration.is_zero() {
+        return f64::INFINITY;
+    }
+    query_count as f64 / duration.as_secs_f64() / 1_000_000.0
+}
+
+fn benchmark_module(path: &Path) {
+    let name = module_name(path);
+
+    let load_result = catch_unwind(AssertUnwindSafe(|| load_module(path)));
+    let module = match load_result {
+        Ok(module) => module,
+        Err(payload) => {
+            println!("{name}\tLOAD_PANIC\t{}", panic_message(&*payload));
+            return;
+        }
+    };
+
+    let construction_start = Instant::now();
+    let construction_result = catch_unwind(AssertUnwindSafe(|| precompute_all(&module)));
+    let construction_time = construction_start.elapsed();
+    let mut analyses = match construction_result {
+        Ok(analyses) => analyses,
+        Err(payload) => {
+            println!(
+                "{name}\tCONSTRUCTION_PANIC\tfunctions={}\tvalues={}\tpoints={}\tqueries={}\tconstruction_ms={:.3}\t{}",
+                module.functions.len(),
+                module.value_count(),
+                module.point_count(),
+                module.query_count,
+                millis(construction_time),
+                panic_message(&*payload)
+            );
+            return;
+        }
+    };
+    black_box(&mut analyses);
+
+    let query_start = Instant::now();
+    let query_result = catch_unwind(AssertUnwindSafe(|| {
+        black_box(run_all_queries(&module, &mut analyses))
+    }));
+    let query_time = query_start.elapsed();
+
+    match query_result {
+        Ok(live_answers) => println!(
+            "{name}\tOK\tfunctions={}\tvalues={}\tpoints={}\tqueries={}\tconstruction_ms={:.3}\tquery_ms={:.3}\tquery_mqps={:.3}\tlive_answers={}",
+            module.functions.len(),
+            module.value_count(),
+            module.point_count(),
+            module.query_count,
+            millis(construction_time),
+            millis(query_time),
+            mega_queries_per_second(module.query_count, query_time),
+            live_answers
+        ),
+        Err(payload) => println!(
+            "{name}\tQUERY_PANIC\tfunctions={}\tvalues={}\tpoints={}\tqueries={}\tconstruction_ms={:.3}\tquery_ms={:.3}\t{}",
+            module.functions.len(),
+            module.value_count(),
+            module.point_count(),
+            module.query_count,
+            millis(construction_time),
+            millis(query_time),
+            panic_message(&*payload)
+        ),
+    }
+}
+
+fn main() {
+    println!(
+        "module\tstatus\tfunctions\tvalues\tpoints\tqueries\tconstruction_ms\tquery_ms\tquery_mqps\tlive_answers"
+    );
+    for path in corpus_files() {
+        benchmark_module(&path);
+    }
+}

--- a/pliron-llvm/llvm-opt/llvm-opt-wrapper.sh
+++ b/pliron-llvm/llvm-opt/llvm-opt-wrapper.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 # Optional overrides:
 #   CLANG=/path/to/clang
 #   LLVM_OPT=/path/to/llvm-opt
+#   PLIRON_LIVENESS_BENCH_DIR=/path/to/corpus
 #
 # Direct invocation (clang-compatible arguments):
 #   ./llvm-opt-wrapper.sh -O2 -g -c foo.c -o foo.o
@@ -150,6 +151,12 @@ for idx in "${!source_files[@]}"; do
     # Step 1: C -> LLVM IR
     "$CLANG_BIN" "${emit_args[@]}" "$src" -S -emit-llvm -O0 -o "$input_ll"
     
+    # Optionally preserve the unoptimized LLVM module for liveness benchmarks.
+    if [[ -n "${PLIRON_LIVENESS_BENCH_DIR:-}" ]]; then
+        mkdir -p "$PLIRON_LIVENESS_BENCH_DIR"
+        cp "$input_ll" "$PLIRON_LIVENESS_BENCH_DIR/${base}.ll"
+    fi
+
     # Step 2: Optimize with llvm-opt
     "$LLVM_OPT_BIN" -S -i "$input_ll" -o "$opt_ll" --opts o1
     

--- a/pliron-llvm/llvm-opt/tests/testsuite/README.md
+++ b/pliron-llvm/llvm-opt/tests/testsuite/README.md
@@ -20,3 +20,24 @@ Each script:
   default: pliron-llvm/llvm-opt/llvm-opt-wrapper.sh
 - LLVM_OPT: path to llvm-opt binary
   default: target/debug/llvm-opt
+
+## Liveness benchmark corpus
+
+Set `PLIRON_LIVENESS_BENCH_DIR` while running a real-world wrapper test to preserve
+the unoptimized LLVM modules emitted by clang. The liveness benchmark consumes all
+`.ll` files found recursively in that directory. It performs one exhaustive
+value/program-point query sweep per module and reports tab-separated timing data.
+A module that triggers a liveness panic is reported and skipped so the remaining
+corpus can still be measured.
+
+Example using bzip2:
+
+```bash
+rm -rf /tmp/pliron-liveness-bzip2
+mkdir -p /tmp/pliron-liveness-bzip2
+cargo build -p llvm-opt
+PLIRON_LIVENESS_BENCH_DIR=/tmp/pliron-liveness-bzip2 \
+  bash pliron-llvm/llvm-opt/tests/testsuite/bzip2.sh
+PLIRON_LIVENESS_BENCH_DIR=/tmp/pliron-liveness-bzip2 \
+  cargo bench -p llvm-opt --bench liveness
+```


### PR DESCRIPTION
Addresses #100.

## Summary

Adds a benchmark harness for the fast SSA liveness implementation requested in #100.

The benchmark runs `Liveness<LivenessTq>` over LLVM modules captured from the existing `llvm-opt` test-suite workflow and measures, independently for each module:

1. liveness construction time;
2. exhaustive liveness query time over every collected value and program point.

## Implementation

The benchmark:

* loads `.ll` modules from `PLIRON_LIVENESS_BENCH_DIR`;
* considers each LLVM module independently;
* collects block arguments and operation results as values;
* collects block start/end and before/after-operation insertion points;
* evaluates the full `values × program points` cross product within each function;
* reports construction time, query time, query throughput, and number of live answers.

The benchmark uses a single timed sweep instead of repeated statistical sampling. Some real modules contain tens of millions of value/point combinations, making repeated Criterion samples prohibitively expensive while not matching the whole-module measurement requested by the issue.

## Corpus

The existing `llvm-opt` wrapper can optionally preserve the input LLVM IR when `PLIRON_LIVENESS_BENCH_DIR` is set.

For example, the bzip2 test suite produces the following benchmark corpus:

* `blocksort.ll`
* `bzip2.ll`
* `bzip2recover.ll`
* `bzlib.ll`
* `compress.ll`
* `crctable.ll`
* `decompress.ll`
* `huffman.ll`
* `randtable.ll`

Corpus generation is opt-in and does not change the normal wrapper behavior.

## Results

On the bzip2 corpus, the benchmark constructs workloads ranging from approximately 0.5 million to more than 80 million value/program-point pairs per module. With the current `LivenessTq` implementation, modules with up to approximately 47 million queries complete successfully.

The Cartesian product is scoped to each function and the measurements are aggregated per module. Cross-function value/program-point pairs are excluded because liveness is defined over a function's CFG and such queries do not represent meaningful liveness checks.

The benchmark also uncovered an existing construction failure in `LivenessTq` for `decompress.ll`:

```text
Cache is too small for this iterator.
```

The failure originates in `hi_sparse_bitset` reduction during liveness precomputation. This PR intentionally does not modify the liveness implementation; that issue can be addressed independently from the benchmark.

## Validation

```bash
cargo fmt --all -- --check
cargo check --workspace --all-targets
cargo bench -p llvm-opt --bench liveness --no-run

PLIRON_LIVENESS_BENCH_DIR=/tmp/pliron-liveness-bzip2 \
cargo bench -p llvm-opt --bench liveness
```

## Checklist
- [x] I have read [CONTRIBUTING.md](../blob/HEAD/CONTRIBUTING.md).
- [x] A human is involved in writing this PR description and will handle
review interactions, per our [AI tool policy](../blob/HEAD/CONTRIBUTING.md).
- [x] I understand every part of this change (including any AI-generated
code) and can explain the reasoning behind it.
- [ ] Intrusive / large changes were discussed on Discord before this PR.
- [x] `pre-ci.sh` passes locally.
