### PR TITLE
[pliron-llvm] Implement constant folding for ExtractValueOp and InsertValueOp

### DIFF
--- a/pliron-llvm/src/interface_impls.rs
+++ b/pliron-llvm/src/interface_impls.rs
@@ -12,15 +12,16 @@ use pliron::{
     attribute::{AttrObj, Attribute, attr_cast},
     basic_block::BasicBlock,
     builtin::{
-        attr_interfaces::FloatAttr,
+        attr_interfaces::{FloatAttr, MaterializableAttr, TypedAttrInterface},
         attributes::IntegerAttr,
         op_interfaces::{BranchOpInterface, OneResultInterface},
         types::{IntegerType, Signedness},
     },
     context::{Context, Ptr},
-    derive::op_interface_impl,
+    derive::{attr_interface_impl, op_interface_impl},
     irbuild::{IRStatus, inserter::Inserter, rewriter::Rewriter},
     op::Op,
+    operation::Operation,
     opts::{
         constants::{BranchOpFoldInterface, ConstFoldInterface},
         dce::{BlockArgRemoval, SideEffects},
@@ -34,7 +35,10 @@ use pliron::{
 };
 
 use crate::{
-    attributes::{FastmathFlags, FastmathFlagsAttr, ICmpPredicateAttr, IntegerOverflowFlagsAttr},
+    attributes::{
+        AggregateAttr, FastmathFlags, FastmathFlagsAttr, ICmpPredicateAttr,
+        IntegerOverflowFlagsAttr,
+    },
     op_interfaces::{FastMathFlags, IntBinArithOpWithOverflowFlag, NNegFlag, PointerTypeResult},
     ops::{
         AShrOp, AddOp, AddressOfOp, AllocaOp, AndOp, BitcastOp, BrOp, CondBrOp, ConstantOp,
@@ -315,6 +319,54 @@ fn fast_math_forbids_fold(flags: FastmathFlagsAttr, values: &[&dyn FloatAttr]) -
     let flags = flags.0;
     (flags.contains(FastmathFlags::NNAN) && values.iter().any(|v| v.is_nan()))
         || (flags.contains(FastmathFlags::NINF) && values.iter().any(|v| v.is_infinite()))
+}
+
+#[attr_interface_impl]
+impl MaterializableAttr for AggregateAttr {
+    fn materialize(&self, ctx: &mut Context) -> Ptr<Operation> {
+        ConstantOp::new(ctx, Box::new(self.clone())).get_operation()
+    }
+}
+
+/// Extract a constant element from an aggregate attribute by following `indices`.
+fn extract_from_aggregate_attr(aggregate: &AggregateAttr, indices: &[u32]) -> Option<AttrObj> {
+    let (&index, rest) = indices.split_first()?;
+    let element = aggregate.elements().get(index as usize)?;
+
+    if rest.is_empty() {
+        return Some(pliron::dyn_clone::clone_box(&**element as &dyn Attribute));
+    }
+
+    let nested = (&**element as &dyn Attribute).downcast_ref::<AggregateAttr>()?;
+    extract_from_aggregate_attr(nested, rest)
+}
+
+/// Insert a constant value into an aggregate attribute by following `indices`.
+fn insert_into_aggregate_attr(
+    ctx: &Context,
+    aggregate: &AggregateAttr,
+    value: &dyn TypedAttrInterface,
+    indices: &[u32],
+) -> Option<AggregateAttr> {
+    let (&index, rest) = indices.split_first()?;
+    let index = index as usize;
+    let current = aggregate.elements().get(index)?;
+
+    let replacement: Box<dyn TypedAttrInterface> = if rest.is_empty() {
+        pliron::dyn_clone::clone_box(value)
+    } else {
+        let nested = (&**current as &dyn Attribute).downcast_ref::<AggregateAttr>()?;
+        Box::new(insert_into_aggregate_attr(ctx, nested, value, rest)?)
+    };
+
+    let mut elements: Vec<Box<dyn TypedAttrInterface>> = aggregate
+        .elements()
+        .iter()
+        .map(|element| pliron::dyn_clone::clone_box(&**element))
+        .collect();
+    elements[index] = replacement;
+
+    Some(AggregateAttr::new(elements, aggregate.get_type(ctx)))
 }
 
 /// Constant fold a binary floating-point operation into a singleton vector
@@ -736,6 +788,58 @@ impl ConstFoldInterface for ZExtOp {
         let res = Box::new(IntegerAttr::new(dest_ty, extended)) as AttrObj;
         vec![Some(res)]
     }
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for ExtractValueOp {
+    fn check_fold(&self, ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        let [Some(aggregate)] = ops else {
+            return vec![None];
+        };
+        let Some(aggregate) = aggregate.downcast_ref::<AggregateAttr>() else {
+            return vec![None];
+        };
+
+        vec![extract_from_aggregate_attr(aggregate, &self.indices(ctx))]
+    }
+
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for InsertValueOp {
+    fn check_fold(&self, ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        let [Some(aggregate), Some(value)] = ops else {
+            return vec![None];
+        };
+        let Some(aggregate) = aggregate.downcast_ref::<AggregateAttr>() else {
+            return vec![None];
+        };
+        let Some(value) = attr_cast::<dyn TypedAttrInterface>(&**value) else {
+            return vec![None];
+        };
+
+        vec![
+            insert_into_aggregate_attr(ctx, aggregate, value, &self.indices(ctx))
+                .map(|result| Box::new(result) as AttrObj),
+        ]
+    }
+
     fn fold_in_place(
         &self,
         ctx: &mut Context,

--- a/pliron-llvm/tests/opts/constants.rs
+++ b/pliron-llvm/tests/opts/constants.rs
@@ -1511,6 +1511,159 @@ fn zext_does_not_fold_with_non_constant_operand() -> Result<()> {
 }
 
 // ---------------------------------------------------------------------------
+// llvm.extract_value
+// ---------------------------------------------------------------------------
+
+#[test]
+fn extract_value_folds_struct_field() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <llvm.aggregate <[builtin.integer <10: i32>, builtin.integer <20: i32>] : llvm.struct <{ builtin.integer i32, builtin.integer i32 } : Unpacked>>> : llvm.struct <{ builtin.integer i32, builtin.integer i32 } : Unpacked>;
+        c = llvm.extract_value a [1] : builtin.integer i32;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("builtin.integer <20: i32>"));
+    Ok(())
+}
+
+#[test]
+fn extract_value_folds_array_element() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i16 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <llvm.aggregate <[builtin.integer <1: i16>, builtin.integer <2: i16>, builtin.integer <3: i16>] : llvm.array [3 x builtin.integer i16]>> : llvm.array [3 x builtin.integer i16];
+        c = llvm.extract_value a [2] : builtin.integer i16;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("builtin.integer <3: i16>"));
+    Ok(())
+}
+
+#[test]
+fn extract_value_folds_nested_path() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <llvm.aggregate <[llvm.aggregate <[builtin.integer <4: i32>, builtin.integer <9: i32>] : llvm.array [2 x builtin.integer i32]>, builtin.integer <7: i8>] : llvm.struct <{ llvm.array [2 x builtin.integer i32], builtin.integer i8 } : Unpacked>>> : llvm.struct <{ llvm.array [2 x builtin.integer i32], builtin.integer i8 } : Unpacked>;
+        c = llvm.extract_value a [0, 1] : builtin.integer i32;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("builtin.integer <9: i32>"));
+    Ok(())
+}
+
+#[test]
+fn extract_value_does_not_fold_with_non_constant_aggregate() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i32 (llvm.struct <{ builtin.integer i32, builtin.integer i32 } : Unpacked>) variadic = false> [] {
+        ^entry(a: llvm.struct <{ builtin.integer i32, builtin.integer i32 } : Unpacked>):
+        c = llvm.extract_value a [0] : builtin.integer i32;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// llvm.insert_value
+// ---------------------------------------------------------------------------
+
+#[test]
+fn insert_value_folds_struct_field() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <llvm.struct <{ builtin.integer i32, builtin.integer i32 } : Unpacked> () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <llvm.aggregate <[builtin.integer <10: i32>, builtin.integer <20: i32>] : llvm.struct <{ builtin.integer i32, builtin.integer i32 } : Unpacked>>> : llvm.struct <{ builtin.integer i32, builtin.integer i32 } : Unpacked>;
+        v = builtin.constant <builtin.integer <99: i32>> : builtin.integer i32;
+        c = llvm.insert_value a [0], v : llvm.struct <{ builtin.integer i32, builtin.integer i32 } : Unpacked>;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(
+        after.contains("llvm.aggregate <[builtin.integer <99: i32>, builtin.integer <20: i32>]")
+    );
+    Ok(())
+}
+
+#[test]
+fn insert_value_folds_array_element() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <llvm.array [3 x builtin.integer i16] () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <llvm.aggregate <[builtin.integer <1: i16>, builtin.integer <2: i16>, builtin.integer <3: i16>] : llvm.array [3 x builtin.integer i16]>> : llvm.array [3 x builtin.integer i16];
+        v = builtin.constant <builtin.integer <8: i16>> : builtin.integer i16;
+        c = llvm.insert_value a [1], v : llvm.array [3 x builtin.integer i16];
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("llvm.aggregate <[builtin.integer <1: i16>, builtin.integer <8: i16>, builtin.integer <3: i16>]"));
+    Ok(())
+}
+
+#[test]
+fn insert_value_folds_nested_path() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <llvm.struct <{ llvm.array [2 x builtin.integer i32], builtin.integer i8 } : Unpacked> () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <llvm.aggregate <[llvm.aggregate <[builtin.integer <4: i32>, builtin.integer <9: i32>] : llvm.array [2 x builtin.integer i32]>, builtin.integer <7: i8>] : llvm.struct <{ llvm.array [2 x builtin.integer i32], builtin.integer i8 } : Unpacked>>> : llvm.struct <{ llvm.array [2 x builtin.integer i32], builtin.integer i8 } : Unpacked>;
+        v = builtin.constant <builtin.integer <11: i32>> : builtin.integer i32;
+        c = llvm.insert_value a [0, 1], v : llvm.struct <{ llvm.array [2 x builtin.integer i32], builtin.integer i8 } : Unpacked>;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("llvm.aggregate <[builtin.integer <4: i32>, builtin.integer <11: i32>] : llvm.array [2 x builtin.integer i32]>"));
+    Ok(())
+}
+
+#[test]
+fn insert_value_does_not_fold_with_non_constant_aggregate() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <llvm.struct <{ builtin.integer i32, builtin.integer i32 } : Unpacked> (llvm.struct <{ builtin.integer i32, builtin.integer i32 } : Unpacked>) variadic = false> [] {
+        ^entry(a: llvm.struct <{ builtin.integer i32, builtin.integer i32 } : Unpacked>):
+        v = builtin.constant <builtin.integer <5: i32>> : builtin.integer i32;
+        c = llvm.insert_value a [1], v : llvm.struct <{ builtin.integer i32, builtin.integer i32 } : Unpacked>;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn insert_value_does_not_fold_with_non_constant_value() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <llvm.struct <{ builtin.integer i32, builtin.integer i32 } : Unpacked> (builtin.integer i32) variadic = false> [] {
+        ^entry(v: builtin.integer i32):
+        a = builtin.constant <llvm.aggregate <[builtin.integer <10: i32>, builtin.integer <20: i32>] : llvm.struct <{ builtin.integer i32, builtin.integer i32 } : Unpacked>>> : llvm.struct <{ builtin.integer i32, builtin.integer i32 } : Unpacked>;
+        c = llvm.insert_value a [1], v : llvm.struct <{ builtin.integer i32, builtin.integer i32 } : Unpacked>;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // llvm.fneg
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Implement `ConstFoldInterface` for the LLVM dialect's `ExtractValueOp` and `InsertValueOp` as part of #118.

The implementation folds constant aggregate accesses and updates, including nested index paths.

## Changes

* Implement constant folding for `ExtractValueOp`.
* Implement constant folding for `InsertValueOp`.
* Support constant LLVM structs and arrays represented by `AggregateAttr`.
* Support nested aggregate index paths.
* Rebuild only the affected aggregate path when folding `insertvalue`.
* Make `AggregateAttr` materializable so SCCP can replace folded aggregate results with `llvm.constant`.
* Leave operations unchanged when the required operands are not constant.
* Add SCCP tests covering:

  * struct field extraction
  * array element extraction
  * nested extraction
  * struct field insertion
  * array element insertion
  * nested insertion
  * non-constant aggregate operands
  * non-constant inserted values

This works on #118 but does not close the issue.

## Testing

Validated with:

```text
cargo test -p pliron-llvm --test opt_tests extract_value -- --nocapture
cargo test -p pliron-llvm --test opt_tests insert_value -- --nocapture
cargo test -p pliron-llvm --test opt_tests

cargo fmt --all -- --check
cargo clippy -p pliron-llvm --all-targets --all-features -- -D warnings

cargo check -p pliron-llvm --no-default-features
RUSTFLAGS="-D warnings" cargo test -p pliron-llvm --no-default-features

./pre-ci.sh
```

All checks pass.

## Checklist

* [x] I have read [CONTRIBUTING.md](../blob/HEAD/CONTRIBUTING.md).
* [x] A human is involved in writing this PR description and will handle review interactions, per our [AI tool policy](../blob/HEAD/CONTRIBUTING.md).
* [x] I understand every part of this change (including any AI-generated code) and can explain the reasoning behind it.
* [ ] Intrusive / large changes were discussed on Discord before this PR.
* [x] `pre-ci.sh` passes locally.
