### PR TITLE
[pliron-llvm] Implement constant folding for ExtractElementOp and InsertElementOp

### DIFF
--- a/pliron-llvm/src/interface_impls.rs
+++ b/pliron-llvm/src/interface_impls.rs
@@ -12,7 +12,7 @@ use pliron::{
     attribute::{AttrObj, Attribute, attr_cast},
     basic_block::BasicBlock,
     builtin::{
-        attr_interfaces::FloatAttr,
+        attr_interfaces::{FloatAttr, TypedAttrInterface},
         attributes::IntegerAttr,
         op_interfaces::{BranchOpInterface, OneResultInterface},
         types::{IntegerType, Signedness},
@@ -34,7 +34,10 @@ use pliron::{
 };
 
 use crate::{
-    attributes::{FastmathFlags, FastmathFlagsAttr, ICmpPredicateAttr, IntegerOverflowFlagsAttr},
+    attributes::{
+        AggregateAttr, FastmathFlags, FastmathFlagsAttr, ICmpPredicateAttr,
+        IntegerOverflowFlagsAttr, SplatAttr,
+    },
     op_interfaces::{FastMathFlags, IntBinArithOpWithOverflowFlag, NNegFlag, PointerTypeResult},
     ops::{
         AShrOp, AddOp, AddressOfOp, AllocaOp, AndOp, BitcastOp, BrOp, CondBrOp, ConstantOp,
@@ -315,6 +318,106 @@ fn fast_math_forbids_fold(flags: FastmathFlagsAttr, values: &[&dyn FloatAttr]) -
     let flags = flags.0;
     (flags.contains(FastmathFlags::NNAN) && values.iter().any(|v| v.is_nan()))
         || (flags.contains(FastmathFlags::NINF) && values.iter().any(|v| v.is_infinite()))
+}
+
+/// Return a constant vector index when `index` is in bounds.
+///
+/// LLVM interprets extractelement/insertelement indices as unsigned integers.
+/// The small-bitwidth case avoids truncating `length` when constructing an APInt
+/// with the index's bitwidth.
+fn constant_vector_index(index: &IntegerAttr, length: usize) -> Option<usize> {
+    let value = index.value();
+    let width = value.bw();
+    let length = u64::try_from(length).ok()?;
+
+    if width < 64 && length >= (1_u64 << width) {
+        return Some(value.to_u128() as usize);
+    }
+
+    let width = NonZero::new(width).expect("index has zero bitwidth");
+    let bound = APInt::from_u64(length, width);
+    value.ult(&bound).then(|| value.to_u128() as usize)
+}
+
+/// Materialize an LLVM constant attribute and replace `old_value` with it.
+///
+/// This is used for vector folds because LLVM aggregate and splat attributes are
+/// valid llvm.constant payloads even though they do not implement the generic
+/// MaterializableAttr interface on this branch.
+fn materialize_llvm_constant_attr(
+    ctx: &mut Context,
+    attr: AttrObj,
+    old_value: Value,
+    rw: &mut dyn Rewriter,
+) -> IRStatus {
+    let Some(typed_attr) = attr_cast::<dyn TypedAttrInterface>(&*attr) else {
+        return IRStatus::Unchanged;
+    };
+    let constant = ConstantOp::new(ctx, pliron::dyn_clone::clone_box(typed_attr));
+    rw.append_operation(ctx, constant.get_operation());
+    rw.replace_value_uses_with(ctx, old_value, constant.get_result(ctx));
+    IRStatus::Changed
+}
+
+/// Extract a scalar constant from a fixed-length vector constant.
+fn extract_vector_element(
+    ctx: &Context,
+    vector: &dyn Attribute,
+    index: &IntegerAttr,
+) -> Option<AttrObj> {
+    if let Some(aggregate) = vector.downcast_ref::<AggregateAttr>() {
+        let index = constant_vector_index(index, aggregate.elements().len())?;
+        return Some(pliron::dyn_clone::clone_box(
+            &*aggregate.elements()[index] as &dyn Attribute,
+        ));
+    }
+
+    let splat = vector.downcast_ref::<SplatAttr>()?;
+    let vector_ty = splat.ty();
+    let vector_ty = vector_ty.deref(ctx);
+    if vector_ty.is_scalable() {
+        return None;
+    }
+    constant_vector_index(index, vector_ty.num_elements() as usize)?;
+    Some(pliron::dyn_clone::clone_box(
+        splat.element() as &dyn Attribute
+    ))
+}
+
+/// Insert a scalar constant into a fixed-length vector constant.
+fn insert_vector_element(
+    ctx: &Context,
+    vector: &dyn Attribute,
+    element: &dyn TypedAttrInterface,
+    index: &IntegerAttr,
+) -> Option<AttrObj> {
+    if let Some(aggregate) = vector.downcast_ref::<AggregateAttr>() {
+        let index = constant_vector_index(index, aggregate.elements().len())?;
+        let mut elements: Vec<Box<dyn TypedAttrInterface>> = aggregate
+            .elements()
+            .iter()
+            .map(|element| pliron::dyn_clone::clone_box(&**element))
+            .collect();
+        elements[index] = pliron::dyn_clone::clone_box(element);
+        return Some(Box::new(AggregateAttr::new(elements, aggregate.get_type(ctx))) as AttrObj);
+    }
+
+    let splat = vector.downcast_ref::<SplatAttr>()?;
+    let vector_ty = splat.ty();
+    let length = {
+        let vector_ty = vector_ty.deref(ctx);
+        if vector_ty.is_scalable() {
+            return None;
+        }
+        vector_ty.num_elements() as usize
+    };
+    let index = constant_vector_index(index, length)?;
+
+    let mut elements: Vec<Box<dyn TypedAttrInterface>> = (0..length)
+        .map(|_| pliron::dyn_clone::clone_box(splat.element()))
+        .collect();
+    elements[index] = pliron::dyn_clone::clone_box(element);
+    Some(Box::new(AggregateAttr::new(elements, vector_ty.into())) as AttrObj)
 }
 
 /// Constant fold a binary floating-point operation into a singleton vector
@@ -743,6 +846,58 @@ impl ConstFoldInterface for ZExtOp {
         rw: &mut dyn Rewriter,
     ) -> IRStatus {
         self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for ExtractElementOp {
+    fn check_fold(&self, ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        let [Some(vector), Some(index)] = ops else {
+            return vec![None];
+        };
+        let Some(index) = index.downcast_ref::<IntegerAttr>() else {
+            return vec![None];
+        };
+
+        vec![extract_vector_element(ctx, &**vector, index)]
+    }
+
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for InsertElementOp {
+    fn check_fold(&self, ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        let [Some(vector), Some(element), Some(index)] = ops else {
+            return vec![None];
+        };
+        let Some(element) = attr_cast::<dyn TypedAttrInterface>(&**element) else {
+            return vec![None];
+        };
+        let Some(index) = index.downcast_ref::<IntegerAttr>() else {
+            return vec![None];
+        };
+
+        vec![insert_vector_element(ctx, &**vector, element, index)]
+    }
+
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        let Some(attr) = self.check_fold(ctx, ops).into_iter().next().flatten() else {
+            return IRStatus::Unchanged;
+        };
+        materialize_llvm_constant_attr(ctx, attr, self.get_result(ctx), rw)
     }
 }
 

--- a/pliron-llvm/tests/opts/constants.rs
+++ b/pliron-llvm/tests/opts/constants.rs
@@ -1511,6 +1511,228 @@ fn zext_does_not_fold_with_non_constant_operand() -> Result<()> {
 }
 
 // ---------------------------------------------------------------------------
+// llvm.extractelement
+// ---------------------------------------------------------------------------
+
+#[test]
+fn extract_element_folds_aggregate_constant() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i32 () variadic = false> [] {
+        ^entry():
+        v = builtin.constant <llvm.aggregate <[builtin.integer <10: i32>, builtin.integer <20: i32>, builtin.integer <30: i32>, builtin.integer <40: i32>] : llvm.vector <Fixed x 4 x builtin.integer i32>>> : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        i = builtin.constant <builtin.integer <2: i32>> : builtin.integer i32;
+        c = llvm.extractelement v, i : builtin.integer i32;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("builtin.constant <builtin.integer <30: i32>>"));
+    Ok(())
+}
+
+#[test]
+fn extract_element_folds_splat_constant() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i32 () variadic = false> [] {
+        ^entry():
+        v = builtin.constant <llvm.splat <builtin.integer <7: i32> : llvm.vector <Fixed x 4 x builtin.integer i32>>> : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        i = builtin.constant <builtin.integer <3: i16>> : builtin.integer i16;
+        c = llvm.extractelement v, i : builtin.integer i32;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("builtin.constant <builtin.integer <7: i32>>"));
+    Ok(())
+}
+
+#[test]
+fn extract_element_folds_small_bitwidth_index() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i32 () variadic = false> [] {
+        ^entry():
+        v = builtin.constant <llvm.aggregate <[builtin.integer <10: i32>, builtin.integer <20: i32>, builtin.integer <30: i32>, builtin.integer <40: i32>] : llvm.vector <Fixed x 4 x builtin.integer i32>>> : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        i = builtin.constant <builtin.integer <1: i1>> : builtin.integer i1;
+        c = llvm.extractelement v, i : builtin.integer i32;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("builtin.constant <builtin.integer <20: i32>>"));
+    Ok(())
+}
+
+#[test]
+fn extract_element_does_not_fold_out_of_bounds_index() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i32 () variadic = false> [] {
+        ^entry():
+        v = builtin.constant <llvm.aggregate <[builtin.integer <10: i32>, builtin.integer <20: i32>, builtin.integer <30: i32>, builtin.integer <40: i32>] : llvm.vector <Fixed x 4 x builtin.integer i32>>> : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        i = builtin.constant <builtin.integer <4: i32>> : builtin.integer i32;
+        c = llvm.extractelement v, i : builtin.integer i32;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn extract_element_treats_index_as_unsigned() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i32 () variadic = false> [] {
+        ^entry():
+        v = builtin.constant <llvm.aggregate <[builtin.integer <10: i32>, builtin.integer <20: i32>, builtin.integer <30: i32>, builtin.integer <40: i32>] : llvm.vector <Fixed x 4 x builtin.integer i32>>> : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        i = builtin.constant <builtin.integer <255: i8>> : builtin.integer i8;
+        c = llvm.extractelement v, i : builtin.integer i32;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn extract_element_does_not_fold_with_non_constant_vector() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i32 (llvm.vector <Fixed x 4 x builtin.integer i32>) variadic = false> [] {
+        ^entry(v: llvm.vector <Fixed x 4 x builtin.integer i32>):
+        i = builtin.constant <builtin.integer <1: i32>> : builtin.integer i32;
+        c = llvm.extractelement v, i : builtin.integer i32;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn extract_element_does_not_fold_with_non_constant_index() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i32 (builtin.integer i32) variadic = false> [] {
+        ^entry(i: builtin.integer i32):
+        v = builtin.constant <llvm.aggregate <[builtin.integer <10: i32>, builtin.integer <20: i32>, builtin.integer <30: i32>, builtin.integer <40: i32>] : llvm.vector <Fixed x 4 x builtin.integer i32>>> : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        c = llvm.extractelement v, i : builtin.integer i32;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// llvm.insertelement
+// ---------------------------------------------------------------------------
+
+#[test]
+fn insert_element_folds_aggregate_constant() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <llvm.vector <Fixed x 4 x builtin.integer i32> () variadic = false> [] {
+        ^entry():
+        v = builtin.constant <llvm.aggregate <[builtin.integer <10: i32>, builtin.integer <20: i32>, builtin.integer <30: i32>, builtin.integer <40: i32>] : llvm.vector <Fixed x 4 x builtin.integer i32>>> : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        e = builtin.constant <builtin.integer <99: i32>> : builtin.integer i32;
+        i = builtin.constant <builtin.integer <1: i32>> : builtin.integer i32;
+        c = llvm.insertelement v, e, i : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("llvm.aggregate <[builtin.integer <10: i32>, builtin.integer <99: i32>, builtin.integer <30: i32>, builtin.integer <40: i32>]"));
+    Ok(())
+}
+
+#[test]
+fn insert_element_folds_splat_constant() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <llvm.vector <Fixed x 4 x builtin.integer i32> () variadic = false> [] {
+        ^entry():
+        v = builtin.constant <llvm.splat <builtin.integer <7: i32> : llvm.vector <Fixed x 4 x builtin.integer i32>>> : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        e = builtin.constant <builtin.integer <11: i32>> : builtin.integer i32;
+        i = builtin.constant <builtin.integer <2: i32>> : builtin.integer i32;
+        c = llvm.insertelement v, e, i : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("llvm.aggregate <[builtin.integer <7: i32>, builtin.integer <7: i32>, builtin.integer <11: i32>, builtin.integer <7: i32>]"));
+    Ok(())
+}
+
+#[test]
+fn insert_element_does_not_fold_out_of_bounds_index() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <llvm.vector <Fixed x 4 x builtin.integer i32> () variadic = false> [] {
+        ^entry():
+        v = builtin.constant <llvm.aggregate <[builtin.integer <10: i32>, builtin.integer <20: i32>, builtin.integer <30: i32>, builtin.integer <40: i32>] : llvm.vector <Fixed x 4 x builtin.integer i32>>> : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        e = builtin.constant <builtin.integer <99: i32>> : builtin.integer i32;
+        i = builtin.constant <builtin.integer <4: i32>> : builtin.integer i32;
+        c = llvm.insertelement v, e, i : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn insert_element_does_not_fold_with_non_constant_vector() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <llvm.vector <Fixed x 4 x builtin.integer i32> (llvm.vector <Fixed x 4 x builtin.integer i32>) variadic = false> [] {
+        ^entry(v: llvm.vector <Fixed x 4 x builtin.integer i32>):
+        e = builtin.constant <builtin.integer <99: i32>> : builtin.integer i32;
+        i = builtin.constant <builtin.integer <1: i32>> : builtin.integer i32;
+        c = llvm.insertelement v, e, i : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn insert_element_does_not_fold_with_non_constant_element() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <llvm.vector <Fixed x 4 x builtin.integer i32> (builtin.integer i32) variadic = false> [] {
+        ^entry(e: builtin.integer i32):
+        v = builtin.constant <llvm.aggregate <[builtin.integer <10: i32>, builtin.integer <20: i32>, builtin.integer <30: i32>, builtin.integer <40: i32>] : llvm.vector <Fixed x 4 x builtin.integer i32>>> : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        i = builtin.constant <builtin.integer <1: i32>> : builtin.integer i32;
+        c = llvm.insertelement v, e, i : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn insert_element_does_not_fold_with_non_constant_index() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <llvm.vector <Fixed x 4 x builtin.integer i32> (builtin.integer i32) variadic = false> [] {
+        ^entry(i: builtin.integer i32):
+        v = builtin.constant <llvm.aggregate <[builtin.integer <10: i32>, builtin.integer <20: i32>, builtin.integer <30: i32>, builtin.integer <40: i32>] : llvm.vector <Fixed x 4 x builtin.integer i32>>> : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        e = builtin.constant <builtin.integer <99: i32>> : builtin.integer i32;
+        c = llvm.insertelement v, e, i : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // llvm.fneg
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Implement `ConstFoldInterface` for the LLVM dialect's `ExtractElementOp` and `InsertElementOp` as part of #118.

The implementation folds constant vector element extraction and insertion for vector constants represented by `AggregateAttr` and `SplatAttr`.

## Changes

* Implement constant folding for `ExtractElementOp`.
* Implement constant folding for `InsertElementOp`.
* Support vector constants represented by `AggregateAttr`.
* Support vector splat constants represented by `SplatAttr`.
* Interpret constant indices as unsigned integers, matching LLVM semantics.
* Support constant indices with different integer bit widths.
* Conservatively avoid folding fixed-vector out-of-bounds indices, which would produce poison.
* Leave operations unchanged when the vector, element, or index operands required for folding are not constant.
* Materialize folded `insertelement` results as `llvm.constant` vector constants.
* Add SCCP tests covering:

  * aggregate vector extraction
  * splat vector extraction
  * aggregate vector insertion
  * splat vector insertion
  * unsigned index interpretation
  * small-bitwidth indices
  * out-of-bounds indices
  * non-constant vectors
  * non-constant elements
  * non-constant indices

This works on #118 but does not close the issue.

## Testing

Validated with:

```text
cargo test -p pliron-llvm --test opt_tests extract_element -- --nocapture
cargo test -p pliron-llvm --test opt_tests insert_element -- --nocapture
cargo test -p pliron-llvm --test opt_tests

cargo fmt --all -- --check
cargo clippy -p pliron-llvm --all-targets --all-features -- -D warnings

cargo check -p pliron-llvm --no-default-features
RUSTFLAGS="-D warnings" cargo test -p pliron-llvm --no-default-features

./pre-ci.sh
```

All checks pass.

## Checklist

* [x] I have read [CONTRIBUTING.md](../blob/HEAD/CONTRIBUTING.md).
* [x] A human is involved in writing this PR description and will handle review interactions, per our [AI tool policy](../blob/HEAD/CONTRIBUTING.md).
* [x] I understand every part of this change (including any AI-generated code) and can explain the reasoning behind it.
* [ ] Intrusive / large changes were discussed on Discord before this PR.
* [x] `pre-ci.sh` passes locally.
