### PR TITLE
[pliron-llvm] Implement constant folding for ShuffleVectorOp

### DIFF
--- a/pliron-llvm/src/interface_impls.rs
+++ b/pliron-llvm/src/interface_impls.rs
@@ -12,7 +12,7 @@ use pliron::{
     attribute::{AttrObj, Attribute, attr_cast},
     basic_block::BasicBlock,
     builtin::{
-        attr_interfaces::FloatAttr,
+        attr_interfaces::{FloatAttr, TypedAttrInterface},
         attributes::IntegerAttr,
         op_interfaces::{BranchOpInterface, OneResultInterface},
         types::{IntegerType, Signedness},
@@ -29,12 +29,16 @@ use pliron::{
         },
     },
     result::Result,
+    r#type::{TypeHandle, Typed},
     utils::apint::{APInt, bw},
     value::Value,
 };
 
 use crate::{
-    attributes::{FastmathFlags, FastmathFlagsAttr, ICmpPredicateAttr, IntegerOverflowFlagsAttr},
+    attributes::{
+        AggregateAttr, FastmathFlags, FastmathFlagsAttr, ICmpPredicateAttr,
+        IntegerOverflowFlagsAttr, SplatAttr,
+    },
     op_interfaces::{FastMathFlags, IntBinArithOpWithOverflowFlag, NNegFlag, PointerTypeResult},
     ops::{
         AShrOp, AddOp, AddressOfOp, AllocaOp, AndOp, BitcastOp, BrOp, CondBrOp, ConstantOp,
@@ -44,6 +48,7 @@ use crate::{
         PtrToIntOp, SDivOp, SExtOp, SIToFPOp, SRemOp, SelectOp, ShlOp, ShuffleVectorOp, StoreOp,
         SubOp, SwitchOp, TruncOp, UDivOp, UIToFPOp, URemOp, UndefOp, XorOp, ZExtOp, ZeroOp,
     },
+    types::VectorType,
 };
 
 #[derive(Error, Debug)]
@@ -743,6 +748,124 @@ impl ConstFoldInterface for ZExtOp {
         rw: &mut dyn Rewriter,
     ) -> IRStatus {
         self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+/// Return the number of elements in a fixed-length vector constant.
+fn fixed_vector_constant_len(ctx: &Context, vector: &dyn Attribute) -> Option<usize> {
+    if let Some(aggregate) = vector.downcast_ref::<AggregateAttr>() {
+        let ty = aggregate.get_type(ctx);
+        let ty = ty.deref(ctx);
+        let vector_ty = ty.downcast_ref::<VectorType>()?;
+        if vector_ty.is_scalable() {
+            return None;
+        }
+        return Some(aggregate.elements().len());
+    }
+
+    let splat = vector.downcast_ref::<SplatAttr>()?;
+    let ty = splat.ty();
+    let ty = ty.deref(ctx);
+    if ty.is_scalable() {
+        return None;
+    }
+    Some(ty.num_elements() as usize)
+}
+
+/// Clone one element from a fixed-length vector constant.
+fn fixed_vector_constant_element(
+    ctx: &Context,
+    vector: &dyn Attribute,
+    index: usize,
+) -> Option<Box<dyn TypedAttrInterface>> {
+    if let Some(aggregate) = vector.downcast_ref::<AggregateAttr>() {
+        let ty = aggregate.get_type(ctx);
+        let ty = ty.deref(ctx);
+        let vector_ty = ty.downcast_ref::<VectorType>()?;
+        if vector_ty.is_scalable() {
+            return None;
+        }
+        return aggregate
+            .elements()
+            .get(index)
+            .map(|element| pliron::dyn_clone::clone_box(&**element));
+    }
+
+    let splat = vector.downcast_ref::<SplatAttr>()?;
+    let ty = splat.ty();
+    let ty = ty.deref(ctx);
+    if ty.is_scalable() || index >= ty.num_elements() as usize {
+        return None;
+    }
+    Some(pliron::dyn_clone::clone_box(splat.element()))
+}
+
+/// Fold a shuffle of two fixed-length vector constants.
+///
+/// Negative mask entries represent poison lanes in LLVM. This helper leaves
+/// those shuffles unfolded rather than materializing a partially-poisoned
+/// aggregate constant.
+fn fold_shuffle_vector(
+    ctx: &Context,
+    lhs: &dyn Attribute,
+    rhs: &dyn Attribute,
+    mask: &[i32],
+    result_ty: TypeHandle,
+) -> Option<AttrObj> {
+    let lhs_len = fixed_vector_constant_len(ctx, lhs)?;
+    let rhs_len = fixed_vector_constant_len(ctx, rhs)?;
+    if lhs_len != rhs_len {
+        return None;
+    }
+    let total_len = lhs_len.checked_add(rhs_len)?;
+
+    let mut elements: Vec<Box<dyn TypedAttrInterface>> = Vec::with_capacity(mask.len());
+    for &mask_index in mask {
+        let index = usize::try_from(mask_index).ok()?;
+        if index >= total_len {
+            return None;
+        }
+        let element = if index < lhs_len {
+            fixed_vector_constant_element(ctx, lhs, index)?
+        } else {
+            fixed_vector_constant_element(ctx, rhs, index - lhs_len)?
+        };
+        elements.push(element);
+    }
+
+    Some(Box::new(AggregateAttr::new(elements, result_ty)) as AttrObj)
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for ShuffleVectorOp {
+    fn check_fold(&self, ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        let [Some(lhs), Some(rhs)] = ops else {
+            return vec![None];
+        };
+        let Some(mask) = self.get_attr_llvm_shuffle_vector_mask(ctx) else {
+            return vec![None];
+        };
+        let result_ty = self.get_result(ctx).get_type(ctx);
+        vec![fold_shuffle_vector(ctx, &**lhs, &**rhs, &mask.0, result_ty)]
+    }
+
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        let Some(attr) = self.check_fold(ctx, ops).into_iter().next().flatten() else {
+            return IRStatus::Unchanged;
+        };
+        let Some(aggregate) = attr.downcast_ref::<AggregateAttr>() else {
+            return IRStatus::Unchanged;
+        };
+
+        let constant = ConstantOp::new(ctx, Box::new(aggregate.clone()));
+        rw.append_operation(ctx, constant.get_operation());
+        rw.replace_value_uses_with(ctx, self.get_result(ctx), constant.get_result(ctx));
+        IRStatus::Changed
     }
 }
 

--- a/pliron-llvm/tests/opts/constants.rs
+++ b/pliron-llvm/tests/opts/constants.rs
@@ -1514,6 +1514,132 @@ fn zext_does_not_fold_with_non_constant_operand() -> Result<()> {
 // llvm.fneg
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// llvm.shuffle_vector
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shuffle_vector_folds_two_aggregate_constants() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <llvm.vector <Fixed x 4 x builtin.integer i32> () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <llvm.aggregate <[builtin.integer <1: i32>, builtin.integer <2: i32>, builtin.integer <3: i32>, builtin.integer <4: i32>] : llvm.vector <Fixed x 4 x builtin.integer i32>>> : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        b = builtin.constant <llvm.aggregate <[builtin.integer <10: i32>, builtin.integer <20: i32>, builtin.integer <30: i32>, builtin.integer <40: i32>] : llvm.vector <Fixed x 4 x builtin.integer i32>>> : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        c = llvm.shuffle_vector a, b, [0, 5, 2, 7] : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains(
+        "llvm.aggregate <[builtin.integer <1: i32>, builtin.integer <20: i32>, builtin.integer <3: i32>, builtin.integer <40: i32>] : llvm.vector <Fixed x 4 x builtin.integer i32>>"
+    ));
+    Ok(())
+}
+
+#[test]
+fn shuffle_vector_selects_second_vector_indices() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <llvm.vector <Fixed x 4 x builtin.integer i32> () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <llvm.aggregate <[builtin.integer <1: i32>, builtin.integer <2: i32>, builtin.integer <3: i32>, builtin.integer <4: i32>] : llvm.vector <Fixed x 4 x builtin.integer i32>>> : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        b = builtin.constant <llvm.aggregate <[builtin.integer <10: i32>, builtin.integer <20: i32>, builtin.integer <30: i32>, builtin.integer <40: i32>] : llvm.vector <Fixed x 4 x builtin.integer i32>>> : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        c = llvm.shuffle_vector a, b, [7, 6, 5, 4] : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains(
+        "llvm.aggregate <[builtin.integer <40: i32>, builtin.integer <30: i32>, builtin.integer <20: i32>, builtin.integer <10: i32>] : llvm.vector <Fixed x 4 x builtin.integer i32>>"
+    ));
+    Ok(())
+}
+
+#[test]
+fn shuffle_vector_folds_aggregate_and_splat_constants() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <llvm.vector <Fixed x 4 x builtin.integer i32> () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <llvm.aggregate <[builtin.integer <1: i32>, builtin.integer <2: i32>, builtin.integer <3: i32>, builtin.integer <4: i32>] : llvm.vector <Fixed x 4 x builtin.integer i32>>> : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        b = builtin.constant <llvm.splat <builtin.integer <9: i32> : llvm.vector <Fixed x 4 x builtin.integer i32>>> : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        c = llvm.shuffle_vector a, b, [4, 1, 6, 3] : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains(
+        "llvm.aggregate <[builtin.integer <9: i32>, builtin.integer <2: i32>, builtin.integer <9: i32>, builtin.integer <4: i32>] : llvm.vector <Fixed x 4 x builtin.integer i32>>"
+    ));
+    Ok(())
+}
+
+#[test]
+fn shuffle_vector_folds_two_splat_constants() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <llvm.vector <Fixed x 4 x builtin.integer i32> () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <llvm.splat <builtin.integer <7: i32> : llvm.vector <Fixed x 4 x builtin.integer i32>>> : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        b = builtin.constant <llvm.splat <builtin.integer <9: i32> : llvm.vector <Fixed x 4 x builtin.integer i32>>> : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        c = llvm.shuffle_vector a, b, [0, 4, 1, 5] : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        llvm.return c
+      }
+    "#;
+    let (status, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains(
+        "llvm.aggregate <[builtin.integer <7: i32>, builtin.integer <9: i32>, builtin.integer <7: i32>, builtin.integer <9: i32>] : llvm.vector <Fixed x 4 x builtin.integer i32>>"
+    ));
+    Ok(())
+}
+
+#[test]
+fn shuffle_vector_does_not_fold_poison_mask_lane() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <llvm.vector <Fixed x 4 x builtin.integer i32> () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <llvm.aggregate <[builtin.integer <1: i32>, builtin.integer <2: i32>, builtin.integer <3: i32>, builtin.integer <4: i32>] : llvm.vector <Fixed x 4 x builtin.integer i32>>> : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        b = builtin.constant <llvm.aggregate <[builtin.integer <10: i32>, builtin.integer <20: i32>, builtin.integer <30: i32>, builtin.integer <40: i32>] : llvm.vector <Fixed x 4 x builtin.integer i32>>> : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        c = llvm.shuffle_vector a, b, [0, -1, 2, 7] : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn shuffle_vector_does_not_fold_with_non_constant_lhs() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <llvm.vector <Fixed x 4 x builtin.integer i32> (llvm.vector <Fixed x 4 x builtin.integer i32>) variadic = false> [] {
+        ^entry(a: llvm.vector <Fixed x 4 x builtin.integer i32>):
+        b = builtin.constant <llvm.aggregate <[builtin.integer <10: i32>, builtin.integer <20: i32>, builtin.integer <30: i32>, builtin.integer <40: i32>] : llvm.vector <Fixed x 4 x builtin.integer i32>>> : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        c = llvm.shuffle_vector a, b, [0, 5, 2, 7] : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn shuffle_vector_does_not_fold_with_non_constant_rhs() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <llvm.vector <Fixed x 4 x builtin.integer i32> (llvm.vector <Fixed x 4 x builtin.integer i32>) variadic = false> [] {
+        ^entry(b: llvm.vector <Fixed x 4 x builtin.integer i32>):
+        a = builtin.constant <llvm.aggregate <[builtin.integer <1: i32>, builtin.integer <2: i32>, builtin.integer <3: i32>, builtin.integer <4: i32>] : llvm.vector <Fixed x 4 x builtin.integer i32>>> : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        c = llvm.shuffle_vector a, b, [0, 5, 2, 7] : llvm.vector <Fixed x 4 x builtin.integer i32>;
+        llvm.return c
+      }
+    "#;
+    let (status, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
 #[test]
 fn fneg_folds_constant() -> Result<()> {
     let input = r#"


### PR DESCRIPTION
## Summary

Implement `ConstFoldInterface` for the LLVM dialect's `ShuffleVectorOp` as part of #118.

The implementation folds constant fixed-length vector shuffles when both input vectors and the shuffle mask are known at compile time.

## Changes

* Implement constant folding for `ShuffleVectorOp`.
* Support vector constants represented by `AggregateAttr`.
* Support vector constants represented by `SplatAttr`.
* Support shuffles combining aggregate and splat constants.
* Select elements from either input vector according to the shuffle mask.
* Materialize the folded result as an `llvm.constant` aggregate vector.
* Conservatively leave scalable vectors unchanged.
* Conservatively leave masks containing poison lanes unchanged.
* Leave the operation unchanged when either input vector is not constant.
* Add SCCP tests covering:

  * two aggregate vector constants
  * indices selecting elements from the second vector
  * aggregate and splat vector constants
  * two splat vector constants
  * poison mask lanes
  * non-constant left-hand operand
  * non-constant right-hand operand

This works on #118 but does not close the issue.

## Testing

Validated with:

```text
cargo test -p pliron-llvm --test opt_tests shuffle_vector -- --nocapture
cargo test -p pliron-llvm --test opt_tests

cargo fmt --all -- --check
cargo clippy -p pliron-llvm --all-targets --all-features -- -D warnings

cargo check -p pliron-llvm --no-default-features
RUSTFLAGS="-D warnings" cargo test -p pliron-llvm --no-default-features

./pre-ci.sh
```

All checks pass.

## Checklist
- [x] I have read [CONTRIBUTING.md](../blob/HEAD/CONTRIBUTING.md).
- [x] I am a human and I have written this PR description myself.
I will also handle review interactions, per the [AI tool policy](../blob/HEAD/CONTRIBUTING.md).
- [x] I have reviewed this PR myself and understand every part of this change
(including any AI-generated code) and can explain the reasoning behind it.
- [x] `pre-ci.sh` passes locally.
- [ ] Intrusive / large changes were discussed on Discord before this PR.
