### PR TITLE
Add flag to skip printing nested regions

### DIFF
--- a/src/graph/visualize.rs
+++ b/src/graph/visualize.rs
@@ -2,7 +2,7 @@
 // Copyright (c) The pliron contributors
 
 use alloc::{format, string::String};
-use core::fmt::Display;
+use core::fmt::{Display, Write as _};
 use pliron::{
     basic_block::BasicBlock,
     common_traits::Named,
@@ -48,6 +48,25 @@ pub fn visualize_region(ctx: &Context, region: Ptr<Region>) -> impl Display + '_
 struct Visualizer<'a> {
     graph_component: IRNode,
     ctx: &'a Context,
+}
+
+/// A string escaped for use as a quoted DOT label.
+struct DotLabel<'a>(&'a str);
+
+impl Display for DotLabel<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("\"")?;
+        for ch in self.0.chars() {
+            match ch {
+                '\\' => f.write_str("\\\\")?,
+                '"' => f.write_str("\\\"")?,
+                '\n' => f.write_str("\\n")?,
+                '\r' => f.write_str("\\r")?,
+                _ => f.write_char(ch)?,
+            }
+        }
+        f.write_str("\"")
+    }
 }
 
 impl core::fmt::Display for Visualizer<'_> {
@@ -191,16 +210,16 @@ fn graphviz_callback(
                 if let Some(parent_block_identifier) = op.deref(ctx).get_parent_block() {
                     format!("{}", parent_block_identifier.deref(ctx).unique_name(ctx))
                 } else {
+                    let label = format!("{}", operation::OpDbg { op, ctx });
                     write!(
                         graph_state.f,
                         " operation_{} [
-                    shape=record,
-                    style=filled, fillcolor=lightgreen, label=\"",
-                        oper_index
+                    shape=box,
+                    style=filled, fillcolor=lightgreen, label={}];\n",
+                        oper_index,
+                        DotLabel(&label),
                     )
                     .to_walk_result()?;
-                    operation::print_dbg(ctx, op, graph_state.f).to_walk_result()?;
-                    writeln!(graph_state.f, "\"];").to_walk_result()?;
                     format!("operation_{}", oper_index)
                 };
 
@@ -222,20 +241,20 @@ fn graphviz_callback(
         }
         IRNode::BasicBlock(block) => {
             let block_identifier: String = block.deref(ctx).unique_name(ctx).into();
+            let mut label = format!("^{block_identifier} :\n");
+            for oper in block.deref(ctx).iter(ctx) {
+                writeln!(&mut label, "{}", operation::OpDbg { op: oper, ctx })
+                    .expect("writing to a String cannot fail");
+            }
             write!(
                 graph_state.f,
                 "{} [
-            shape=record,
-            style=filled, fillcolor=lightgreen, label=\"",
-                block_identifier
+            shape=box,
+            style=filled, fillcolor=lightgreen, label={}];\n",
+                block_identifier,
+                DotLabel(&label),
             )
             .to_walk_result()?;
-            write!(graph_state.f, "{} : \\n", block_identifier).to_walk_result()?;
-            for oper in block.deref(ctx).iter(ctx) {
-                operation::print_dbg(ctx, oper, graph_state.f).to_walk_result()?;
-                write!(graph_state.f, "\\n").to_walk_result()?;
-            }
-            writeln!(graph_state.f, "\"];").to_walk_result()?;
             for succ in block.deref(ctx).succs(ctx) {
                 let succ_identifier: String = succ.deref(ctx).unique_name(ctx).into();
                 writeln!(graph_state.f, "{}->{};", block_identifier, succ_identifier)
@@ -261,13 +280,32 @@ fn graphviz_callback(
                 .unwrap();
             let op_id = Operation::get_op_dyn(parent_op, ctx).get_opid();
             let parent_op_label = &op_id.name;
+            let label = format!("parent_op : {parent_op_label}, region_idx : {region_idx}");
             write!(
                 graph_state.f,
-                "subgraph cluster_region_{0}_{1}{{ \n style=dotted;\n label=\"parent_op : {2}, region_idx : {1}\";\n",
-                oper_index, region_idx, parent_op_label,
-            ).to_walk_result()?;
+                "subgraph cluster_region_{0}_{1}{{ \n style=dotted;\n label={2};\n",
+                oper_index,
+                region_idx,
+                DotLabel(&label),
+            )
+            .to_walk_result()?;
         }
     }
 
     walk_advance()
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::format;
+
+    use super::DotLabel;
+
+    #[test]
+    fn dot_label_escapes_quoted_string_syntax() {
+        assert_eq!(
+            format!("{}", DotLabel("quotes: \"; slash: \\;\nnext line\r")),
+            "\"quotes: \\\"; slash: \\\\;\\nnext line\\r\""
+        );
+    }
 }

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -912,7 +912,7 @@ pub fn print_dbg(
     f: &mut core::fmt::Formatter<'_>,
 ) -> core::fmt::Result {
     let state = printable::State::default();
-    state.set_max_region_depth_printed(printable::MaxRegionDepthPrinted::Depth(0));
+    state.set_region_print_depth_limit(printable::RegionPrintDepthLimit::Max(0));
     // `Operation::printable` prints outlined attributes, which we don't want here.
     // So call the `Op` printer directly
     Operation::get_op_dyn(opr, ctx).fmt(ctx, &state, f)

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -5,17 +5,14 @@
 //! The general idea is similar to MLIR's
 //! [Operation](https://mlir.llvm.org/docs/LangRef/#operations)
 
-use alloc::{format, string::ToString, vec, vec::Vec};
+use alloc::{string::ToString, vec, vec::Vec};
 use core::marker::PhantomData;
 use thiserror::Error;
 
 use crate::{
     attribute::{AttributeDict, verify_attr},
     basic_block::{BasicBlock, BasicBlockVerifyErr},
-    builtin::{
-        given_names,
-        op_interfaces::{IsTerminatorInterface, SymbolOpInterface},
-    },
+    builtin::{given_names, op_interfaces::IsTerminatorInterface},
     combine::{Parser, attempt, parser::char::spaces, token},
     common_traits::{Named, RcShare, Verify},
     context::{Arena, Context, Ptr, private::ArenaObj},
@@ -32,11 +29,10 @@ use crate::{
     irfmt::{
         outlined::{self, parse_outlines, postparse_outline},
         parsers::{list_parser, location, spaced},
-        printers::iter_with_sep,
     },
     linked_list::{LinkedList, private},
     location::{Located, Location},
-    op::{ConcreteOpInfo, Op, OpId, OpObj, op_cast, op_impls},
+    op::{ConcreteOpInfo, Op, OpId, OpObj, op_impls},
     parsable::{self, Parsable, ParseResult, StateStream},
     printable::{self, Printable},
     region::Region,
@@ -909,57 +905,17 @@ impl Parsable for Operation {
     }
 }
 
-/// Print basic [Operation] information, mainly for logging / debugging.
-///
-/// Includes the operation's unique identifier, its operands, and its successors.
-/// Does not include attributes or regions, and is not meant to be a user-facing print.
+/// Print an [Operation] using its normal printer with all regions elided.
 pub fn print_dbg(
     ctx: &Context,
     opr: Ptr<Operation>,
     f: &mut core::fmt::Formatter<'_>,
 ) -> core::fmt::Result {
-    let sep = printable::ListSeparator::CharSpace(',');
-
-    let op = Operation::get_op_dyn(opr, ctx);
-    let opid = op.get_opid();
-    let opr = opr.deref(ctx);
-    let operands = iter_with_sep(opr.operands(), sep);
-
-    let symbol_opt = match op_cast::<dyn SymbolOpInterface>(&*op) {
-        Some(sym_op) => " @".to_string() + &sym_op.get_symbol_name(ctx).disp(ctx).to_string(),
-        None => "".to_string(),
-    };
-
-    // Print [Ptr] representing this operation.
-    write!(f, "[{:?}] ", opr.get_self_ptr(ctx))?;
-
-    if opr.get_num_results() > 0 {
-        let results = iter_with_sep(opr.results(), sep);
-        write!(f, "{} = ", results.disp(ctx))?;
-    }
-
-    write!(
-        f,
-        "{}{} ({})",
-        opid.disp(ctx),
-        symbol_opt,
-        operands.disp(ctx)
-    )?;
-
-    if opr.get_num_successors() > 0 {
-        let successors = iter_with_sep(
-            opr.successors()
-                .map(|succ| format!("^{}", succ.unique_name(ctx))),
-            sep,
-        );
-        write!(f, " [{}]", successors.disp(ctx))?;
-    }
-
-    if !op.loc(ctx).is_unknown() {
-        write!(f, " [@{}]", op.loc(ctx).disp(ctx))?;
-    }
-
-    Ok(())
+    let state = printable::State::default();
+    state.set_max_region_depth_printed(printable::MaxRegionDepthPrinted::Depth(0));
+    // `Operation::printable` prints outlined attributes, which we don't want here.
+    // So call the `Op` printer directly
+    Operation::get_op_dyn(opr, ctx).fmt(ctx, &state, f)
 }
 
 /// A helper type that implements [Display](core::fmt::Display) and [Debug](core::fmt::Debug)

--- a/src/printable.rs
+++ b/src/printable.rs
@@ -14,12 +14,12 @@ use crate::{common_traits::RcShare, context::Context, identifier::Identifier, ut
 
 /// Maximum number of nested region levels to print.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum MaxRegionDepthPrinted {
+pub enum RegionPrintDepthLimit {
     /// Print all regions without a depth limit.
     #[default]
-    None,
+    Unlimited,
     /// Print at most this many region levels; zero elides every region.
-    Depth(u32),
+    Max(u32),
 }
 
 struct StateInner {
@@ -27,10 +27,8 @@ struct StateInner {
     indent_width: u16,
     // Current indentation
     cur_indent: u16,
-    // Maximum number of nested region levels to print
-    max_region_depth_printed: MaxRegionDepthPrinted,
-    // Current region nesting depth
-    cur_region_depth: u32,
+    // Maximum number of nested region levels to print.
+    region_print_depth_limit: RegionPrintDepthLimit,
     // Arbitrary state data that different printers may want to use.
     aux_data: HMap<Identifier, Box<dyn Any>>,
 }
@@ -41,8 +39,7 @@ impl Default for StateInner {
             indent_width: 2,
             cur_indent: 0,
             aux_data: HMap::default(),
-            max_region_depth_printed: MaxRegionDepthPrinted::None,
-            cur_region_depth: 0,
+            region_print_depth_limit: RegionPrintDepthLimit::Unlimited,
         }
     }
 }
@@ -86,27 +83,31 @@ impl State {
     }
 
     /// Set the maximum number of nested region levels to print.
-    pub fn set_max_region_depth_printed(&self, depth: MaxRegionDepthPrinted) {
-        self.0.borrow_mut().max_region_depth_printed = depth;
+    pub fn set_region_print_depth_limit(&self, limit: RegionPrintDepthLimit) {
+        self.0.borrow_mut().region_print_depth_limit = limit;
     }
 
-    /// Enter a region if the depth limit permits it.
-    /// Returns false without changing the depth when the region must be elided.
+    /// Enter a region if the remaining depth limit permits it.
+    /// Returns false without changing the limit when the region must be elided.
     /// Every successful push must be paired with [Self::pop_region_depth].
     pub fn push_region_depth(&self) -> bool {
         let mut inner = self.0.borrow_mut();
-        if let MaxRegionDepthPrinted::Depth(max) = inner.max_region_depth_printed
-            && inner.cur_region_depth >= max
-        {
-            return false;
+        match &mut inner.region_print_depth_limit {
+            RegionPrintDepthLimit::Unlimited => true,
+            RegionPrintDepthLimit::Max(0) => false,
+            RegionPrintDepthLimit::Max(remaining) => {
+                *remaining -= 1;
+                true
+            }
         }
-        inner.cur_region_depth += 1;
-        true
     }
 
     /// Leave a region previously entered by [Self::push_region_depth].
     pub fn pop_region_depth(&self) {
-        self.0.borrow_mut().cur_region_depth -= 1;
+        let mut inner = self.0.borrow_mut();
+        if let RegionPrintDepthLimit::Max(remaining) = &mut inner.region_print_depth_limit {
+            *remaining += 1;
+        }
     }
 
     /// Get a reference to the aux data table. The returned [Ref] is borrowed

--- a/src/printable.rs
+++ b/src/printable.rs
@@ -12,12 +12,26 @@ use core::{
 
 use crate::{common_traits::RcShare, context::Context, identifier::Identifier, utils::table::HMap};
 
+/// Maximum number of nested region levels to print.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum MaxRegionDepthPrinted {
+    /// Print all regions without a depth limit.
+    #[default]
+    None,
+    /// Print at most this many region levels; zero elides every region.
+    Depth(u32),
+}
+
 struct StateInner {
     // Number of spaces per indentation
     indent_width: u16,
     // Current indentation
     cur_indent: u16,
-    // Aribtrary state data that different printers may want to use.
+    // Maximum number of nested region levels to print
+    max_region_depth_printed: MaxRegionDepthPrinted,
+    // Current region nesting depth
+    cur_region_depth: u32,
+    // Arbitrary state data that different printers may want to use.
     aux_data: HMap<Identifier, Box<dyn Any>>,
 }
 
@@ -27,6 +41,8 @@ impl Default for StateInner {
             indent_width: 2,
             cur_indent: 0,
             aux_data: HMap::default(),
+            max_region_depth_printed: MaxRegionDepthPrinted::None,
+            cur_region_depth: 0,
         }
     }
 }
@@ -67,6 +83,30 @@ impl State {
     pub fn pop_indent(&self) {
         let mut inner = self.0.as_ref().borrow_mut();
         inner.cur_indent -= inner.indent_width;
+    }
+
+    /// Set the maximum number of nested region levels to print.
+    pub fn set_max_region_depth_printed(&self, depth: MaxRegionDepthPrinted) {
+        self.0.borrow_mut().max_region_depth_printed = depth;
+    }
+
+    /// Enter a region if the depth limit permits it.
+    /// Returns false without changing the depth when the region must be elided.
+    /// Every successful push must be paired with [Self::pop_region_depth].
+    pub fn push_region_depth(&self) -> bool {
+        let mut inner = self.0.borrow_mut();
+        if let MaxRegionDepthPrinted::Depth(max) = inner.max_region_depth_printed
+            && inner.cur_region_depth >= max
+        {
+            return false;
+        }
+        inner.cur_region_depth += 1;
+        true
+    }
+
+    /// Leave a region previously entered by [Self::push_region_depth].
+    pub fn pop_region_depth(&self) {
+        self.0.borrow_mut().cur_region_depth -= 1;
     }
 
     /// Get a reference to the aux data table. The returned [Ref] is borrowed

--- a/src/region.rs
+++ b/src/region.rs
@@ -10,7 +10,7 @@ use crate::{
     combine::{Parser, parser::char::spaces, token},
     common_traits::Verify,
     context::{Context, Ptr, private::ArenaObj},
-    dict_key, indented_block,
+    indented_block,
     linked_list::{ContainsLinkedList, private},
     location::Located,
     op::op_cast,
@@ -167,8 +167,6 @@ impl Verify for Region {
     }
 }
 
-dict_key!(PRINTABLE_FLAG_SKIP_REGIONS, "printable_skip_regions");
-
 impl Printable for Region {
     fn fmt(
         &self,
@@ -176,16 +174,9 @@ impl Printable for Region {
         state: &printable::State,
         f: &mut core::fmt::Formatter<'_>,
     ) -> core::fmt::Result {
-        let skip_regions = || {
-            let data = state.aux_data_ref();
-            let Some(entry) = data.get(&PRINTABLE_FLAG_SKIP_REGIONS) else {
-                return false;
-            };
-            entry.downcast_ref().copied().unwrap_or(false)
-        };
-
-        if skip_regions() {
-            return f.write_str("{ .. }");
+        if !state.push_region_depth() {
+            // We want this to fail to parse.
+            return f.write_str("{..}");
         }
 
         fmt_indented_newline(state, f)?;
@@ -204,6 +195,7 @@ impl Printable for Region {
 
         fmt_indented_newline(state, f)?;
         write!(f, "}}")?;
+        state.pop_region_depth();
         Ok(())
     }
 }

--- a/src/region.rs
+++ b/src/region.rs
@@ -10,7 +10,7 @@ use crate::{
     combine::{Parser, parser::char::spaces, token},
     common_traits::Verify,
     context::{Context, Ptr, private::ArenaObj},
-    indented_block,
+    dict_key, indented_block,
     linked_list::{ContainsLinkedList, private},
     location::Located,
     op::op_cast,
@@ -167,6 +167,8 @@ impl Verify for Region {
     }
 }
 
+dict_key!(PRINTABLE_FLAG_SKIP_REGIONS, "printable_skip_regions");
+
 impl Printable for Region {
     fn fmt(
         &self,
@@ -174,6 +176,18 @@ impl Printable for Region {
         state: &printable::State,
         f: &mut core::fmt::Formatter<'_>,
     ) -> core::fmt::Result {
+        let skip_regions = || {
+            let data = state.aux_data_ref();
+            let Some(entry) = data.get(&PRINTABLE_FLAG_SKIP_REGIONS) else {
+                return false;
+            };
+            entry.downcast_ref().copied().unwrap_or(false)
+        };
+
+        if skip_regions() {
+            return f.write_str("{ .. }");
+        }
+
         fmt_indented_newline(state, f)?;
         write!(f, "{{")?;
 

--- a/tests/ir_construct.rs
+++ b/tests/ir_construct.rs
@@ -1721,3 +1721,67 @@ fn erase_given_names_roundtrip() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+#[cfg_attr(target_family = "wasm", wasm_bindgen_test)]
+fn print_region_depth_limit() -> Result<()> {
+    use pliron::{
+        operation::OpDbg,
+        printable::{MaxRegionDepthPrinted, State},
+    };
+
+    let ctx = &mut Context::new();
+    let (module, _, _, _) = const_ret_in_mod(ctx)?;
+    let state = State::default();
+    let full = module.disp(ctx).to_string();
+    let expected_full = expect![[r#"
+        builtin.module @bar 
+        {
+          ^block1v1():
+            builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
+            {
+              ^entry_block2v1():
+                c0_v0 = test.constant builtin.integer <0: si64> !0;
+                test.return c0_v0
+            }
+        }"#]];
+    expected_full.assert_eq(&full);
+
+    state.set_max_region_depth_printed(MaxRegionDepthPrinted::Depth(0));
+    let expected_shallow = expect![["builtin.module @bar {..}"]];
+    expected_shallow.assert_eq(&module.print(ctx, &state).to_string());
+    let dbg = OpDbg {
+        op: module.get_operation(),
+        ctx,
+    };
+    expected_shallow.assert_eq(&format!("{dbg}"));
+    expected_shallow.assert_eq(&format!("{dbg:?}"));
+
+    state.set_max_region_depth_printed(MaxRegionDepthPrinted::Depth(1));
+    let expected_one_level = expect![[r#"
+        builtin.module @bar 
+        {
+          ^block1v1():
+            builtin.func @foo: builtin.function <() -> (builtin.integer si64)> {..}
+        }"#]];
+    expected_one_level.assert_eq(&module.print(ctx, &state).to_string());
+    // Printing restores the region depth, so reusing the state should produce identical output.
+    expected_one_level.assert_eq(&module.print(ctx, &state).to_string());
+
+    state.set_max_region_depth_printed(MaxRegionDepthPrinted::Depth(2));
+    expected_full.assert_eq(&module.print(ctx, &state).to_string());
+    state.set_max_region_depth_printed(MaxRegionDepthPrinted::None);
+    expect![[r#"
+        builtin.module @bar 
+        {
+          ^block1v1():
+            builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
+            {
+              ^entry_block2v1():
+                c0_v0 = test.constant builtin.integer <0: si64> !1;
+                test.return c0_v0
+            }
+        }"#]]
+    .assert_eq(&module.print(ctx, &state).to_string());
+    Ok(())
+}

--- a/tests/ir_construct.rs
+++ b/tests/ir_construct.rs
@@ -1727,7 +1727,7 @@ fn erase_given_names_roundtrip() -> Result<()> {
 fn print_region_depth_limit() -> Result<()> {
     use pliron::{
         operation::OpDbg,
-        printable::{MaxRegionDepthPrinted, State},
+        printable::{RegionPrintDepthLimit, State},
     };
 
     let ctx = &mut Context::new();
@@ -1747,7 +1747,7 @@ fn print_region_depth_limit() -> Result<()> {
         }"#]];
     expected_full.assert_eq(&full);
 
-    state.set_max_region_depth_printed(MaxRegionDepthPrinted::Depth(0));
+    state.set_region_print_depth_limit(RegionPrintDepthLimit::Max(0));
     let expected_shallow = expect![["builtin.module @bar {..}"]];
     expected_shallow.assert_eq(&module.print(ctx, &state).to_string());
     let dbg = OpDbg {
@@ -1757,7 +1757,7 @@ fn print_region_depth_limit() -> Result<()> {
     expected_shallow.assert_eq(&format!("{dbg}"));
     expected_shallow.assert_eq(&format!("{dbg:?}"));
 
-    state.set_max_region_depth_printed(MaxRegionDepthPrinted::Depth(1));
+    state.set_region_print_depth_limit(RegionPrintDepthLimit::Max(1));
     let expected_one_level = expect![[r#"
         builtin.module @bar 
         {
@@ -1768,9 +1768,9 @@ fn print_region_depth_limit() -> Result<()> {
     // Printing restores the region depth, so reusing the state should produce identical output.
     expected_one_level.assert_eq(&module.print(ctx, &state).to_string());
 
-    state.set_max_region_depth_printed(MaxRegionDepthPrinted::Depth(2));
+    state.set_region_print_depth_limit(RegionPrintDepthLimit::Max(2));
     expected_full.assert_eq(&module.print(ctx, &state).to_string());
-    state.set_max_region_depth_printed(MaxRegionDepthPrinted::None);
+    state.set_region_print_depth_limit(RegionPrintDepthLimit::Unlimited);
     expect![[r#"
         builtin.module @bar 
         {


### PR DESCRIPTION
## Description

This adds a simple flag to allow skipping nested regions when printing. I didn't want to add some new flags mechanism to the printing state so it's implemented as an `aux_data`, but it could become a native value like the indent if that's preferred.

I used  `{ .. }` as a stub for regions because it matches Rust pattern matching syntax and preserves some indication that there is in fact a region there.

## Motivation

A lot of analyses are anchored on operations (or program points, which usually point to an operation). It's currently very difficult to debug these analyses because printing a region-containing op prints all of the nested ops as well, which makes the output nearly unreadable. The flag ensures regions are stubbed out instead, so region ops can still be rendered in one line. It would be up to the analysis printing code to set this flag.
In terms of prior art, MLIR has a very similar printing mode, for the same purpose.

## Checklist
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I am a human and I have written this PR description myself.
I will also handle review interactions, per the [AI tool policy](../CONTRIBUTING.md).
- [x] I have reviewed this PR myself and understand every part of this change
(including any AI-generated code) and can explain the reasoning behind it.
- [x] Intrusive / large changes were discussed on Discord before this PR.
- [x] `pre-ci.sh` passes locally.
